### PR TITLE
Develop: Fixed Compiler warnings

### DIFF
--- a/include/LeMonADE/analyzer/AnalyzerRadiusOfGyration.h
+++ b/include/LeMonADE/analyzer/AnalyzerRadiusOfGyration.h
@@ -136,13 +136,12 @@ AnalyzerRadiusOfGyration<IngredientsType>::AnalyzerRadiusOfGyration(const Ingred
 								    std::string filenamePrefix,
 								    uint64_t lowerMcsLimit)
 :ingredients(ing)
-,outputFilePrefix(filenamePrefix)
-,lowerLimit(lowerMcsLimit)
 ,Rg_squaredX(1)
 ,Rg_squaredY(1)
 ,Rg_squaredZ(1)
 ,Rg_squared(1)
-
+,lowerLimit(lowerMcsLimit)
+,outputFilePrefix(filenamePrefix)
 {
 	groups.push_back(MonomerGroup<molecules_type>(&(ing.getMolecules())));
 	
@@ -159,12 +158,12 @@ AnalyzerRadiusOfGyration<IngredientsType>::AnalyzerRadiusOfGyration(const Ingred
 								    ,std::string filenamePrefix
 								    ,uint64_t lowerMcsLimit)
 :ingredients(ing)
-,outputFilePrefix(filenamePrefix)
-,lowerLimit(lowerMcsLimit)
 ,Rg_squaredX(1)
 ,Rg_squaredY(1)
 ,Rg_squaredZ(1)
 ,Rg_squared(1)
+,lowerLimit(lowerMcsLimit)
+,outputFilePrefix(filenamePrefix)
 {
 	//add the group given as argument to groups. groups will only consist of this single group
 	groups.push_back(g);
@@ -178,12 +177,12 @@ AnalyzerRadiusOfGyration<IngredientsType>::AnalyzerRadiusOfGyration(const Ingred
 								    uint64_t lowerMcsLimit)
 :ingredients(ing)
 ,groups(g)
-,outputFilePrefix(filenamePrefix)
-,lowerLimit(lowerMcsLimit)
 ,Rg_squaredX(g.size())
 ,Rg_squaredY(g.size())
 ,Rg_squaredZ(g.size())
 ,Rg_squared(g.size())
+,lowerLimit(lowerMcsLimit)
+,outputFilePrefix(filenamePrefix)
 {
 }
 

--- a/include/LeMonADE/analyzer/AnalyzerWriteBfmFile.h
+++ b/include/LeMonADE/analyzer/AnalyzerWriteBfmFile.h
@@ -126,6 +126,9 @@ private:
   
   //! The filename to be used.
   std::string _filename;
+  
+    //! Storage for data that are processed to file (mostly Ingredients).
+  const IngredientsType& ingredients;
 
   //! The output file stream.
   std::ofstream file;
@@ -136,9 +139,6 @@ private:
   //bfm Write strings with associated write objects
   //! Vector of pairs of Write-strings (e.g. !box_x) associated Write objects
   std::vector < std::pair<std::string, SuperAbstractWrite*> > WriteObjects;
-
-  //! Storage for data that are processed to file (mostly Ingredients).
-  const IngredientsType& ingredients;
 
   //init-flag to see if the initialize() routine was called. this
   //is necessary, because it opens the file and writes the header

--- a/include/LeMonADE/core/MoleculesRead.h
+++ b/include/LeMonADE/core/MoleculesRead.h
@@ -170,16 +170,15 @@ class ReadMcs: public ReadToDestination < IngredientsType >
 	//! Ignores if monomer position is missing in the !mcs (maybe due to solvent)
 	bool ignore_missing_monos;
 
-
+	//! The number of frames/conformations/!mcs-command in file.
+	uint32_t nFrames;
+	
 	/**
 	 * @brief Return if first !mcs is read-in, already.
 	 *
 	 * @return \a True if first call/occurance of !mcs - \a False otherwise.
 	 */
 	bool isFirstCall() const {return first_call;}
-
-	//! The number of frames/conformations/!mcs-command in file.
-	uint32_t nFrames;
 	
 	//! processes a regular mcs line from a stream
 	void processRegularLine(const std::string& line);
@@ -194,10 +193,11 @@ class ReadMcs: public ReadToDestination < IngredientsType >
  public:
   //! Empty Constructor, but delegates call to the Feature. Default: no ignoring of missing monomers.
   ReadMcs(IngredientsType& destination):ReadToDestination< IngredientsType > (destination)
-  ,ignore_missing_monos(false)
+  ,monomerCount(0)
   ,first_call(true)
+  ,ignore_missing_monos(false)
   ,nFrames(0)
-  ,monomerCount(0){}
+  {}
   
   /**
    * @brief Set this if missing monomers should ignore by read-in (maybe due to solvent).

--- a/include/LeMonADE/feature/FeatureLatticeBase.h
+++ b/include/LeMonADE/feature/FeatureLatticeBase.h
@@ -152,7 +152,7 @@ protected:
 //!constructor
 template<template<typename> class SpecializedClass, typename ValueType>
 FeatureLatticeBase<SpecializedClass<ValueType> >::FeatureLatticeBase()
-	:lattice(NULL),proXY(0),xPro(0),_boxX(0),_boxY(0),_boxZ(0),boxXm1(0),boxYm1(0),boxZm1(0)
+	:_boxX(0),_boxY(0),_boxZ(0),boxXm1(0),boxYm1(0),boxZm1(0),xPro(0),proXY(0),lattice(NULL)
 {
 
 }

--- a/include/LeMonADE/io/FileImport.h
+++ b/include/LeMonADE/io/FileImport.h
@@ -226,8 +226,7 @@ private:
  */
 template <class IngredientsType>
 FileImport<IngredientsType>::FileImport(const std::string& sourcefile,IngredientsType& dataStorage)
-  :bfmData(dataStorage),filename(sourcefile),firstMcs(0),
-   parser(file)
+  :bfmData(dataStorage),filename(sourcefile),parser(file),firstMcs(0)
 {
   //open the source file
   file.open(sourcefile.c_str(),std::ios_base::in|std::ios_base::binary);

--- a/include/LeMonADE/io/Parser.h
+++ b/include/LeMonADE/io/Parser.h
@@ -44,7 +44,7 @@ along with LeMonADE.  If not, see <http://www.gnu.org/licenses/>.
  * @class Parser
  *
  * @brief Basic parser for files in *.bfm-format
- * 
+ * */
 /*****************************************************************************/
 class Parser
 {

--- a/include/LeMonADE/updater/UpdaterReadBfmFile.h
+++ b/include/LeMonADE/updater/UpdaterReadBfmFile.h
@@ -209,14 +209,15 @@ public:
   void closeFile(){file.close();}
   
 private:
-    //! ENUM-type BFM_READ_TYPE specify the read-in
-	int myReadType;
-
 	//! A reference to the IngredientsType - mainly the system
 	IngredientsType& ingredients;
 
 	//! FileImport to read-in the configurations.
 	FileImport<IngredientsType> file;
+
+	//! ENUM-type BFM_READ_TYPE specify the read-in
+	int myReadType;
+
 };
 
 #endif

--- a/include/LeMonADE/utility/TaskManager.h
+++ b/include/LeMonADE/utility/TaskManager.h
@@ -143,9 +143,9 @@ public:
     }
   };
 private:
-  bool isFirstExecution;
-  unsigned int execution_period;
   AbstractAnalyzer* myAnalyzer;
+  unsigned int execution_period;
+  bool isFirstExecution;
 };
 
 /*****************************************************************************/
@@ -188,9 +188,9 @@ public:
   }
   
 private:
-  bool isFirstExecution;
-  unsigned int execution_period;
   AbstractUpdater* myUpdater;
+  unsigned int execution_period;
+  bool isFirstExecution;
 };
 
 #endif /* LEMONADE_UTILITY_TASKMANAGER_H */

--- a/projects/Examples/example0/ex0main.cpp
+++ b/projects/Examples/example0/ex0main.cpp
@@ -122,6 +122,12 @@ int main(int argc, char* argv[]){
    **********************************************************************/
   
   VectorDouble3 vectorDouble_a=vector32;  //this works
+  std::cout<<"Assignment of VectorInt3 to VectorDouble3 works:\n"
+		<<"\tDouble\tInt\n"
+	   <<"x\t"<<vectorDouble_a.getX()<<"\t"<<vector32.getX()<<"\n"
+	   <<"y\t"<<vectorDouble_a.getY()<<"\t"<<vector32.getY()<<"\n"
+	   <<"z\t"<<vectorDouble_a.getZ()<<"\t"<<vector32.getZ()<<"\n"
+	   <<std::endl;
 
   //uncommenting the following line will result in a compiler error
   //VectorInt3 vector32_d=vectorDouble;

--- a/projects/Examples/example4/ex4main.cpp
+++ b/projects/Examples/example4/ex4main.cpp
@@ -93,7 +93,7 @@ int main(int argc, char* argv[]){
     mySystem.modifyMolecules()[0].setY(0);
     mySystem.modifyMolecules()[0].setZ(0);
     
-    for(int i=1;i<polymerLength;i++){
+    for(uint32_t i=1;i<polymerLength;i++){
 	    mySystem.modifyMolecules()[i].setX(i*2);
 	    mySystem.modifyMolecules()[i].setY(i*2);	
 	    mySystem.modifyMolecules()[i].setZ(i);

--- a/src/LeMonADE/utility/ResultFormattingTools.cpp
+++ b/src/LeMonADE/utility/ResultFormattingTools.cpp
@@ -42,7 +42,7 @@ void ResultFormattingTools::addComment(std::stringstream& stream) {
 	stream.clear();
 	stream.seekp(0);//ios_base::beg);
 
-	for (int i = 0; i < v.size(); ++i) {
+	for (size_t i = 0; i < v.size(); ++i) {
 		stream << v[i];
 	}
 	return;

--- a/src/LeMonADE/utility/SlowBondset.cpp
+++ b/src/LeMonADE/utility/SlowBondset.cpp
@@ -236,7 +236,8 @@ bool SlowBondset::isValid(const VectorInt3& bondVector ) const
   uint32_t z=bondVector.getZ()+lookupOffset;
   
   //if bondvectors are within coordinate range of lookup, see if they are valid
-  if(x<=2*lookupOffset && y<=2*lookupOffset && z<=2*lookupOffset)
+  //lookup offset cannot be negative, so conversion is save
+  if(x<=2*uint32_t(lookupOffset) && y<=2*uint32_t(lookupOffset) && z<=2*uint32_t(lookupOffset))
     return bondsetLookup[x][y][z];
   //otherwise always return false
   else return false;


### PR DESCRIPTION
Fixed all compiler warnings being shown when compiling libLeMonADE-static, SimpleSimulator and Examples with flag -Wall. Most Warnings were due to signed-unsigned comparison and wrong order in the initialization lists of constructors. Tests should be ok, at least they were on my machine.
