### PR TITLE
Feature Excluded Volume spezialized for Sc and Bcc Bfm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ Debug/
 /docs/latex/
 /build/*
 /Build/*
+Makefile

--- a/include/LeMonADE/feature/FeatureExcludedVolume.h
+++ b/include/LeMonADE/feature/FeatureExcludedVolume.h
@@ -257,8 +257,8 @@ bool FeatureExcludedVolume< SpecializedClass<ValueType> >::checkMove(
 	throw std::runtime_error("*****FeatureExcludedVolume_T::checkMove....lattice is not populated. Run synchronize!\n");
 #endif
 
-	int x, y, z;
-	char dx, dy, dz;
+	int32_t x, y, z;
+	int8_t dx, dy, dz;
 	x = ingredients.getMolecules()[move.getIndex()][0];
 	y = ingredients.getMolecules()[move.getIndex()][1];
 	z = ingredients.getMolecules()[move.getIndex()][2];

--- a/include/LeMonADE/feature/FeatureExcludedVolumeBcc.h
+++ b/include/LeMonADE/feature/FeatureExcludedVolumeBcc.h
@@ -1,0 +1,394 @@
+/*--------------------------------------------------------------------------------
+    ooo      L   attice-based  |
+  o\.|./o    e   xtensible     | LeMonADE: An Open Source Implementation of the
+ o\.\|/./o   Mon te-Carlo      |           Bond-Fluctuation-Model for Polymers
+oo---0---oo  A   lgorithm and  |
+ o/./|\.\o   D   evelopment    | Copyright (C) 2013-2015 by 
+  o/.|.\o    E   nvironment    | LeMonADE Principal Developers (see AUTHORS)
+    ooo                        | 
+----------------------------------------------------------------------------------
+
+This file is part of LeMonADE.
+
+LeMonADE is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+LeMonADE is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with LeMonADE.  If not, see <http://www.gnu.org/licenses/>.
+
+--------------------------------------------------------------------------------*/
+
+#ifndef LEMONADE_FEATURE_FEATUREEXCLUDEDVOLUMEBCC_H
+#define LEMONADE_FEATURE_FEATUREEXCLUDEDVOLUMEBCC_H
+
+#include <LeMonADE/feature/Feature.h>
+#include <LeMonADE/feature/FeatureLattice.h>
+#include <LeMonADE/feature/FeatureLatticePowerOfTwo.h>
+
+#include <LeMonADE/updater/moves/MoveBase.h>
+#include <LeMonADE/updater/moves/MoveLocalBcc.h>
+#include <LeMonADE/updater/moves/MoveAddBccMonomer.h>
+
+
+/*****************************************************************************/
+/**
+ * @file
+ * @date   2016/02/18
+ * @author Ron and Martin
+ *
+ * @class FeatureExcludedVolumeBcc
+ * @brief This Feature adds excluded volume check to the system.
+ * It is specialised to the body centered cubic lattice.
+ * 
+ * @details The excluded volume is checked by a lattice occupation algorithm
+ * on a body centered cubic lattice.
+ * The feature is implemented as a class template, where the template parameters 
+ * \a SpecializedClass and \a ValueTypes specify, what
+ * type of lattice is used and which kind of value is saved on the lattice.
+ * This feature requires FeatureLattice.
+ * Notice: only implementations of Bcc moves included to avoid a mix of 
+ * FeatureExcludedVolumeBcc and MoveLocalSc.
+ *
+ * @tparam <SpecializedClass<ValueType>> name of the specialized class.
+ * Default is FeatureLattice.
+ * 
+ * @tparam <ValueType> type of the lattice value. Default is bool.
+ * */
+/*****************************************************************************/
+
+/**
+ * @brief Forward declaration. Equivalent to FeatureExcludedVolumeBcc< FeatureLattice <bool> >
+ */
+template<class SpecializedClass = FeatureLattice<> > class FeatureExcludedVolumeBcc;
+
+///////////////////////////////////////////////////////////////////////////////
+//DEFINITION OF THE CLASS TEMPLATE   	                                ///////
+//Implementation of the members below					///////
+///////////////////////////////////////////////////////////////////////////////
+
+template<template<typename> class SpecializedClass, typename ValueType>
+class FeatureExcludedVolumeBcc< SpecializedClass<ValueType> > : public Feature {
+public:
+	//! This Feature requires a lattice.
+	typedef LOKI_TYPELIST_1(SpecializedClass<ValueType>) required_features_front;
+
+	//constructor
+	FeatureExcludedVolumeBcc() :
+			latticeFilledUp(false) 
+	{
+	}
+
+	/**
+	 * Returns true if the underlying lattice is synchronized and all excluded volume condition
+	 * (e.g. monomer/vertex occupies lattice edges) is applied.
+	 * Returns false if this feature is out-of-sync.
+	 *
+	 *
+	 * @return true if this feature is synchronized
+	 * 		   false if this feature is out-of-sync.
+	 **/
+	bool isLatticeFilledUp() const {
+		return latticeFilledUp;
+	}
+
+	/**
+	 * Set's the need of synchronization of this feature e.g. escp. if the underlying lattice needs
+	 * to refilled and if all excluded volume condition needs to be updated.
+	 *
+	 *
+	 * @param[in] latticeFilledUp Specified if ExVol should be refilled (false) or everything is in-sync (true).
+	 *
+	 **/
+	void setLatticeFilledUp(bool latticeFilledUp) {
+		this->latticeFilledUp = latticeFilledUp;
+	}
+
+	//! check move for basic move - always true
+	template<class IngredientsType>
+	bool checkMove(const IngredientsType& ingredients, const MoveBase& move) const;
+
+	//! check move for bcc local move
+	template<class IngredientsType>
+	bool checkMove(const IngredientsType& ingredients, const MoveLocalBcc& move) const;
+
+	//! check move for adding a bcc monomer
+	template<class IngredientsType>
+	bool checkMove(const IngredientsType& ingredients, const MoveAddBccMonomer& move) const;
+
+	//! apply move for basic moves - does nothing
+	template<class IngredientsType>
+	void applyMove(IngredientsType& ing, const MoveBase& move);
+
+	//! apply move for local bcc moves
+	template<class IngredientsType>
+	void applyMove(IngredientsType& ing, const MoveLocalBcc& move);
+	
+	//! apply move for adding an bcc monomer
+	template<class IngredientsType>
+	void applyMove(IngredientsType& ing, const MoveAddBccMonomer& move);
+
+	//! Synchronize with system: Fill the lattice with 1 (occupied) and 0 (free).
+	template<class IngredientsType>
+	void synchronize(IngredientsType& ingredients);
+
+private:
+
+	//! Populates the lattice using the coordinates of molecules.
+	template<class IngredientsType> void fillLattice(
+			IngredientsType& ingredients);
+
+	//! Tag for indication if the lattice is populated.
+	bool latticeFilledUp;
+
+};
+
+///////////////////////////////////////////////////////////////////////////////
+////////////////////////// member definitions /////////////////////////////////
+
+/******************************************************************************/
+/**
+ * @fn bool FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::checkMove( const IngredientsType& ingredients, const MoveBase& move )const
+ * @brief Returns true for all moves other than the ones that have specialized versions of this function.
+ * This dummy function is implemented for generality.
+ *
+ * @param [in] ingredients A reference to the IngredientsType - mainly the system
+ * @param [in] move General move other than MoveLocalSc or MoveLocalBcc.
+ * @return true Always!
+ */
+/******************************************************************************/
+//template<class  SpecializedClass<ValueType> >
+template<template<typename> class SpecializedClass, typename ValueType>
+template<class IngredientsType>
+bool FeatureExcludedVolumeBcc< SpecializedClass<ValueType> >::checkMove(
+		const IngredientsType& ingredients, const MoveBase& move) const
+		{
+	return true;
+}
+
+/******************************************************************************/
+/**
+ * @fn void FeatureExcludedVolumeBcc< SpecializedClass<ValueType> >::applyMove(IngredientsType& ing, const MoveBase& move)
+ * @brief This function applies for unknown moves other than the ones that have specialized versions of this function.
+ * It does nothing and is implemented for generality.
+ *
+ * @param [in] ingredients A reference to the IngredientsType - mainly the system
+ * @param [in] move General move other than MoveLocalSc or MoveLocalBcc.
+ */
+/******************************************************************************/
+template<template<typename> class SpecializedClass, typename ValueType>
+template<class IngredientsType>
+void FeatureExcludedVolumeBcc< SpecializedClass<ValueType> >::applyMove(IngredientsType& ing,
+const MoveBase& move)
+{
+
+}
+
+/******************************************************************************/
+/**
+ * @fn bool FeatureExcludedVolumeBcc< SpecializedClass<ValueType> >::checkMove( const IngredientsType& ingredients, const MoveLocalBcc& move )const
+ * @brief checks excluded volume for moves of type MoveLocalBcc
+ * 
+ * @param [in] ingredients A reference to the IngredientsType - mainly the system.
+ * @param [in] move A reference to MoveLocalBcc.
+ * @return if move is allowed (\a true) or rejected (\a false).
+ */
+/******************************************************************************/
+template<template<typename> class SpecializedClass, typename ValueType>
+template<class IngredientsType>
+bool FeatureExcludedVolumeBcc< SpecializedClass<ValueType> >::checkMove(const IngredientsType& ingredients, const MoveLocalBcc& move) const
+{
+	if(!latticeFilledUp)
+	  throw std::runtime_error("*****FeatureExcludedVolumeBcc_T::checkMove....lattice is not populated. Run synchronize!\n");
+
+	int32_t x, y, z;
+	int8_t dx, dy, dz;
+	x = ingredients.getMolecules()[move.getIndex()][0];
+	y = ingredients.getMolecules()[move.getIndex()][1];
+	z = ingredients.getMolecules()[move.getIndex()][2];
+
+	dx = 2 * move.getDir()[0];
+	dy = 2 * move.getDir()[1];
+	dz = 2 * move.getDir()[2];
+
+	if (ingredients.getLatticeEntry(x + dx, y, z) ||
+			ingredients.getLatticeEntry(x, y + dy, z) ||
+			ingredients.getLatticeEntry(x, y, z + dz) ||
+			ingredients.getLatticeEntry(x + dx, y + dy, z) ||
+			ingredients.getLatticeEntry(x + dx, y, z + dz) ||
+			ingredients.getLatticeEntry(x, y + dy, z + dz) ||
+			ingredients.getLatticeEntry(x + dx, y + dy, z + dz)
+					)
+		return false;
+	else
+		return true;
+}
+
+/******************************************************************************/
+/**
+ * @fn void FeatureExcludedVolumeBcc< SpecializedClass<ValueType> >::applyMove(IngredientsType& ing, const MoveLocalBcc& move)
+ * @brief Updates the lattice occupation according to the move for moves of type MoveLocalBcc. 
+ * 
+ * @param [in] ingredients A reference to the IngredientsType - mainly the system.
+ * @param [in] move A reference to MoveLocalSBcc.
+ * */
+/******************************************************************************/
+template<template<typename> class SpecializedClass, typename ValueType>
+template<class IngredientsType>
+void FeatureExcludedVolumeBcc< SpecializedClass<ValueType> >::applyMove(IngredientsType& ing, const MoveLocalBcc& move)
+{
+	if (!latticeFilledUp)
+		throw std::runtime_error("*****FeatureExcludedVolumeBcc_T::applyMove....lattice is not populated. Run synchronize!\n");
+	//get old position and direction of the move
+	VectorInt3 oldPos = ing.getMolecules()[move.getIndex()];
+	VectorInt3 direction = move.getDir();
+
+	//change lattice occupation accordingly
+	ing.moveOnLattice(oldPos, oldPos + direction);
+
+}
+
+/******************************************************************************/
+/**
+ * @fn bool FeatureExcludedVolumeBcc< SpecializedClass<ValueType> >::checkMove( const IngredientsType& ingredients, const MoveAddBccMonomer& move )const
+ * @brief check excluded volume for insertion of a monomer on a bcc lattice
+ * 
+ * @param [in] ingredients A reference to the IngredientsType - mainly the system.
+ * @param [in] move A reference to MoveAddBccMonomer.
+ * */
+/******************************************************************************/
+template<template<typename> class SpecializedClass, typename ValueType>
+template < class IngredientsType>
+bool FeatureExcludedVolumeBcc< SpecializedClass<ValueType> >::checkMove( const IngredientsType& ingredients, const MoveAddBccMonomer& move ) const
+{
+  if (!latticeFilledUp)
+	throw std::runtime_error("*****FeatureExcludedVolume_T::checkMove....lattice is not populated. Run synchronize!\n");
+  
+  //check if position coordinates are all even or all odd
+  VectorInt3 pos=move.getPosition();
+  if( ( ((pos.getX())&1) != ((pos.getY())&1) )  || ( ((pos.getX())&1) != ((pos.getZ())&1) ) ){
+    return false;
+  }
+  
+  VectorInt3 dx(1,0,0);
+  VectorInt3 dy(0,1,0);
+  VectorInt3 dz(0,0,1);
+  
+  if(ingredients.getLatticeEntry(pos) || 
+    ingredients.getLatticeEntry(pos + dx + dy + dz) || /* check "o" lattice */
+    ingredients.getLatticeEntry(pos - dx + dy + dz) ||
+    ingredients.getLatticeEntry(pos + dx - dy + dz) ||
+    ingredients.getLatticeEntry(pos - dx - dy + dz) ||
+    ingredients.getLatticeEntry(pos + dx + dy - dz) ||
+    ingredients.getLatticeEntry(pos - dx + dy - dz) ||
+    ingredients.getLatticeEntry(pos + dx - dy - dz) ||
+    ingredients.getLatticeEntry(pos - dx - dy - dz) ){
+    return false;
+  }else{
+    //check "x" lattice
+    int8_t counter(0);
+    if(ingredients.getLatticeEntry(pos+ 2*dx)) counter++;
+    if(ingredients.getLatticeEntry(pos- 2*dx)) counter++;
+    if(ingredients.getLatticeEntry(pos+ 2*dy)) counter++;
+    if(ingredients.getLatticeEntry(pos- 2*dy)) counter++;
+    if(ingredients.getLatticeEntry(pos+ 2*dz)) counter++;
+    if(ingredients.getLatticeEntry(pos- 2*dz)) counter++;
+    
+    //! @todo think about counter for "x" lattice check (<2) ... is it too restrictive?
+    if(counter < 2)
+      return true;
+    else
+      return false;
+  }
+}
+
+/******************************************************************************/
+/**
+ * @fn void FeatureExcludedVolumeBcc< SpecializedClass<ValueType> >::applyMove( const IngredientsType& ingredients, const MoveAddBccMonomer& move )const
+ * @brief apply excluded volume for MoveAddBccMonomer.
+ * 
+ * @param [in] ingredients A reference to the IngredientsType - mainly the system.
+ * @param [in] move A reference to MoveAddBccMonomer.
+ * */
+/******************************************************************************/
+template<template<typename> class SpecializedClass, typename ValueType>
+template<class IngredientsType> 
+void FeatureExcludedVolumeBcc< SpecializedClass<ValueType> >::applyMove(IngredientsType& ing, const MoveAddBccMonomer& move)
+{
+  ing.setLatticeEntry(move.getPosition(),1);
+}
+
+/**
+ * Synchronizes the lattice occupation with the rest of the system.
+ * The lattice is filled with information about the occupation.
+ *
+ * @param ingredients A reference to the IngredientsType - mainly the system.
+ */
+template<template<typename> class SpecializedClass, typename ValueType>
+template<class IngredientsType>
+void FeatureExcludedVolumeBcc< SpecializedClass<ValueType> >::synchronize(
+		IngredientsType& ingredients)
+		{
+	//note: the lattice entries are set to 0 before by the 
+	//synchronize function of FeatureLattice
+	std::cout << "FeatureExcludedVolumeBcc_T::synchronizing lattice occupation...";
+	fillLattice(ingredients);
+	std::cout << "done\n";
+}
+
+
+/**
+ * This function populates the lattice directly with positions from molecules
+ * e.g. sets the value at the (relative) monomer position on the lattice to 1.
+ * It also has a simple check if the target lattice is already occupied.
+ *
+ * @param ingredients A reference to the IngredientsType - mainly the system.
+ */
+
+template<template<typename> class SpecializedClass, typename ValueType>
+template<class IngredientsType>
+void FeatureExcludedVolumeBcc< SpecializedClass<ValueType> >::fillLattice(
+		IngredientsType& ingredients)
+		{
+	const typename IngredientsType::molecules_type& molecules =
+			ingredients.getMolecules();
+			
+
+	//copy the lattice occupation from the monomer coordinates
+	for (size_t n = 0; n < molecules.size(); n++)
+	{
+		// iterates over the monomer cube.
+
+		for ( int x = -1 ; x < 2; ++x)
+		for ( int y = -1 ; y < 2; ++y)
+		for ( int z = -1 ; z < 2; ++z)
+		{		      
+			VectorInt3 pos = molecules[n]+VectorInt3(x,y,z);
+			
+			if (ingredients.getLatticeEntry(pos))
+			{
+				std::ostringstream errorMessage; 
+				errorMessage << "FeatureExcludedVolumeBcc<>::fillLattice(): lattice already occupied when trying to write monomer ";
+				errorMessage << n << " at " << molecules[n] << ", cube corner at " << pos << ".\n"; 
+				throw std::runtime_error(errorMessage.str());
+			}
+			//here we simply set a one on every occupied lattice
+			//site. this assumes that 1 can be cast to LatticeType,
+			//even though in principle LatticeType could be anything.
+			//note that this may be just a preliminiary initialization,
+			//as other features may assign more specific values to the
+			//lattice site.
+		}
+		ingredients.setLatticeEntry(molecules[n],1);
+	}
+	latticeFilledUp = true;
+}
+
+
+#endif

--- a/include/LeMonADE/feature/FeatureExcludedVolumeBcc.h
+++ b/include/LeMonADE/feature/FeatureExcludedVolumeBcc.h
@@ -35,6 +35,8 @@ along with LeMonADE.  If not, see <http://www.gnu.org/licenses/>.
 #include <LeMonADE/updater/moves/MoveBase.h>
 #include <LeMonADE/updater/moves/MoveLocalBcc.h>
 #include <LeMonADE/updater/moves/MoveAddBccMonomer.h>
+#include <LeMonADE/updater/moves/MoveLocalSc.h>
+#include <LeMonADE/updater/moves/MoveAddScMonomer.h>
 
 
 /*****************************************************************************/
@@ -117,10 +119,18 @@ public:
 	//! check move for bcc local move
 	template<class IngredientsType>
 	bool checkMove(const IngredientsType& ingredients, const MoveLocalBcc& move) const;
+	
+	//! check sc move: Throw error if wrong lattice Type is used
+	template<class IngredientsType>
+	bool checkMove(const IngredientsType& ingredients, const MoveLocalSc& move) const;
 
 	//! check move for adding a bcc monomer
 	template<class IngredientsType>
 	bool checkMove(const IngredientsType& ingredients, const MoveAddBccMonomer& move) const;
+	
+	//! check addsc move: Throw error if wrong lattice Type is used
+	template<class IngredientsType>
+	bool checkMove(const IngredientsType& ingredients, const MoveAddScMonomer& move) const;
 
 	//! apply move for basic moves - does nothing
 	template<class IngredientsType>
@@ -192,6 +202,44 @@ const MoveBase& move)
 
 /******************************************************************************/
 /**
+ * @fn bool FeatureExcludedVolumeSc< LatticeClassType<LatticeValueType> >::checkMove( const IngredientsType& ingredients, const MoveLocalSc& move )const
+ * @brief Throws a runtime error because the lattice type is inconsitent with the move type
+ *
+ * @param [in] ingredients A reference to the IngredientsType - mainly the system
+ * @param [in] move MoveLocalSc
+ * @return false, throws exception
+ */
+/******************************************************************************/
+template<template<typename> class LatticeClassType, typename LatticeValueType>
+template<class IngredientsType>
+bool FeatureExcludedVolumeBcc< LatticeClassType<LatticeValueType> >::checkMove(
+const IngredientsType& ingredients, const MoveLocalSc& move) const
+{
+	throw std::runtime_error("*****FeatureExcludedVolumeSc::check MoveLocalSc: wrong lattice type ... \n");
+	return false;
+}
+
+/******************************************************************************/
+/**
+ * @fn bool FeatureExcludedVolumeSc< LatticeClassType<LatticeValueType> >::checkMove( const IngredientsType& ingredients, const MoveAddScMonomer& move )const
+ * @brief Throws a runtime error because the lattice type is inconsitent with the move type
+ *
+ * @param [in] ingredients A reference to the IngredientsType - mainly the system
+ * @param [in] move MoveAddScMonomer
+ * @return false, throws exception
+ */
+/******************************************************************************/
+template<template<typename> class LatticeClassType, typename LatticeValueType>
+template<class IngredientsType>
+bool FeatureExcludedVolumeBcc< LatticeClassType<LatticeValueType> >::checkMove(
+const IngredientsType& ingredients, const MoveAddScMonomer& move) const
+{
+	throw std::runtime_error("*****FeatureExcludedVolumeSc::check MoveAddScMonomer: wrong lattice type ... \n");
+	return false;
+}
+
+/******************************************************************************/
+/**
  * @fn bool FeatureExcludedVolumeBcc< LatticeClassType<LatticeValueType> >::checkMove( const IngredientsType& ingredients, const MoveLocalBcc& move )const
  * @brief checks excluded volume for moves of type MoveLocalBcc
  * 
@@ -205,7 +253,7 @@ template<class IngredientsType>
 bool FeatureExcludedVolumeBcc< LatticeClassType<LatticeValueType> >::checkMove(const IngredientsType& ingredients, const MoveLocalBcc& move) const
 {
 	if(!latticeFilledUp)
-	  throw std::runtime_error("*****FeatureExcludedVolumeBcc_T::checkMove....lattice is not populated. Run synchronize!\n");
+	  throw std::runtime_error("*****FeatureExcludedVolumeBcc::checkMove....lattice is not populated. Run synchronize!\n");
 
 	int32_t x, y, z;
 	int8_t dx, dy, dz;
@@ -244,7 +292,7 @@ template<class IngredientsType>
 void FeatureExcludedVolumeBcc< LatticeClassType<LatticeValueType> >::applyMove(IngredientsType& ing, const MoveLocalBcc& move)
 {
 	if (!latticeFilledUp)
-		throw std::runtime_error("*****FeatureExcludedVolumeBcc_T::applyMove....lattice is not populated. Run synchronize!\n");
+		throw std::runtime_error("*****FeatureExcludedVolumeBcc::applyMove....lattice is not populated. Run synchronize!\n");
 	//get old position and direction of the move
 	VectorInt3 oldPos = ing.getMolecules()[move.getIndex()];
 	VectorInt3 direction = move.getDir();
@@ -337,7 +385,7 @@ void FeatureExcludedVolumeBcc< LatticeClassType<LatticeValueType> >::synchronize
 		{
 	//note: the lattice entries are set to 0 before by the 
 	//synchronize function of FeatureLattice
-	std::cout << "FeatureExcludedVolumeBcc_T::synchronizing lattice occupation...";
+	std::cout << "FeatureExcludedVolumeBcc::synchronizing lattice occupation...";
 	fillLattice(ingredients);
 	std::cout << "done\n";
 }

--- a/include/LeMonADE/feature/FeatureExcludedVolumeBcc.h
+++ b/include/LeMonADE/feature/FeatureExcludedVolumeBcc.h
@@ -50,34 +50,34 @@ along with LeMonADE.  If not, see <http://www.gnu.org/licenses/>.
  * @details The excluded volume is checked by a lattice occupation algorithm
  * on a body centered cubic lattice.
  * The feature is implemented as a class template, where the template parameters 
- * \a SpecializedClass and \a ValueTypes specify, what
+ * \a LatticeClassType and \a LatticeValueTypes specify, what
  * type of lattice is used and which kind of value is saved on the lattice.
  * This feature requires FeatureLattice.
  * Notice: only implementations of Bcc moves included to avoid a mix of 
  * FeatureExcludedVolumeBcc and MoveLocalSc.
  *
- * @tparam <SpecializedClass<ValueType>> name of the specialized class.
+ * @tparam <LatticeClassType<LatticeValueType>> name of the specialized class.
  * Default is FeatureLattice.
  * 
- * @tparam <ValueType> type of the lattice value. Default is bool.
+ * @tparam <LatticeValueType> type of the lattice value. Default is bool.
  * */
 /*****************************************************************************/
 
 /**
  * @brief Forward declaration. Equivalent to FeatureExcludedVolumeBcc< FeatureLattice <bool> >
  */
-template<class SpecializedClass = FeatureLattice<> > class FeatureExcludedVolumeBcc;
+template<class LatticeClassType = FeatureLattice<> > class FeatureExcludedVolumeBcc;
 
 ///////////////////////////////////////////////////////////////////////////////
 //DEFINITION OF THE CLASS TEMPLATE   	                                ///////
 //Implementation of the members below					///////
 ///////////////////////////////////////////////////////////////////////////////
 
-template<template<typename> class SpecializedClass, typename ValueType>
-class FeatureExcludedVolumeBcc< SpecializedClass<ValueType> > : public Feature {
+template<template<typename> class LatticeClassType, typename LatticeValueType>
+class FeatureExcludedVolumeBcc< LatticeClassType<LatticeValueType> > : public Feature {
 public:
 	//! This Feature requires a lattice.
-	typedef LOKI_TYPELIST_1(SpecializedClass<ValueType>) required_features_front;
+	typedef LOKI_TYPELIST_1(LatticeClassType<LatticeValueType>) required_features_front;
 
 	//constructor
 	FeatureExcludedVolumeBcc() :
@@ -154,7 +154,7 @@ private:
 
 /******************************************************************************/
 /**
- * @fn bool FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::checkMove( const IngredientsType& ingredients, const MoveBase& move )const
+ * @fn bool FeatureExcludedVolumeSc< LatticeClassType<LatticeValueType> >::checkMove( const IngredientsType& ingredients, const MoveBase& move )const
  * @brief Returns true for all moves other than the ones that have specialized versions of this function.
  * This dummy function is implemented for generality.
  *
@@ -163,10 +163,10 @@ private:
  * @return true Always!
  */
 /******************************************************************************/
-//template<class  SpecializedClass<ValueType> >
-template<template<typename> class SpecializedClass, typename ValueType>
+//template<class  LatticeClassType<LatticeValueType> >
+template<template<typename> class LatticeClassType, typename LatticeValueType>
 template<class IngredientsType>
-bool FeatureExcludedVolumeBcc< SpecializedClass<ValueType> >::checkMove(
+bool FeatureExcludedVolumeBcc< LatticeClassType<LatticeValueType> >::checkMove(
 		const IngredientsType& ingredients, const MoveBase& move) const
 		{
 	return true;
@@ -174,7 +174,7 @@ bool FeatureExcludedVolumeBcc< SpecializedClass<ValueType> >::checkMove(
 
 /******************************************************************************/
 /**
- * @fn void FeatureExcludedVolumeBcc< SpecializedClass<ValueType> >::applyMove(IngredientsType& ing, const MoveBase& move)
+ * @fn void FeatureExcludedVolumeBcc< LatticeClassType<LatticeValueType> >::applyMove(IngredientsType& ing, const MoveBase& move)
  * @brief This function applies for unknown moves other than the ones that have specialized versions of this function.
  * It does nothing and is implemented for generality.
  *
@@ -182,9 +182,9 @@ bool FeatureExcludedVolumeBcc< SpecializedClass<ValueType> >::checkMove(
  * @param [in] move General move other than MoveLocalSc or MoveLocalBcc.
  */
 /******************************************************************************/
-template<template<typename> class SpecializedClass, typename ValueType>
+template<template<typename> class LatticeClassType, typename LatticeValueType>
 template<class IngredientsType>
-void FeatureExcludedVolumeBcc< SpecializedClass<ValueType> >::applyMove(IngredientsType& ing,
+void FeatureExcludedVolumeBcc< LatticeClassType<LatticeValueType> >::applyMove(IngredientsType& ing,
 const MoveBase& move)
 {
 
@@ -192,7 +192,7 @@ const MoveBase& move)
 
 /******************************************************************************/
 /**
- * @fn bool FeatureExcludedVolumeBcc< SpecializedClass<ValueType> >::checkMove( const IngredientsType& ingredients, const MoveLocalBcc& move )const
+ * @fn bool FeatureExcludedVolumeBcc< LatticeClassType<LatticeValueType> >::checkMove( const IngredientsType& ingredients, const MoveLocalBcc& move )const
  * @brief checks excluded volume for moves of type MoveLocalBcc
  * 
  * @param [in] ingredients A reference to the IngredientsType - mainly the system.
@@ -200,9 +200,9 @@ const MoveBase& move)
  * @return if move is allowed (\a true) or rejected (\a false).
  */
 /******************************************************************************/
-template<template<typename> class SpecializedClass, typename ValueType>
+template<template<typename> class LatticeClassType, typename LatticeValueType>
 template<class IngredientsType>
-bool FeatureExcludedVolumeBcc< SpecializedClass<ValueType> >::checkMove(const IngredientsType& ingredients, const MoveLocalBcc& move) const
+bool FeatureExcludedVolumeBcc< LatticeClassType<LatticeValueType> >::checkMove(const IngredientsType& ingredients, const MoveLocalBcc& move) const
 {
 	if(!latticeFilledUp)
 	  throw std::runtime_error("*****FeatureExcludedVolumeBcc_T::checkMove....lattice is not populated. Run synchronize!\n");
@@ -232,16 +232,16 @@ bool FeatureExcludedVolumeBcc< SpecializedClass<ValueType> >::checkMove(const In
 
 /******************************************************************************/
 /**
- * @fn void FeatureExcludedVolumeBcc< SpecializedClass<ValueType> >::applyMove(IngredientsType& ing, const MoveLocalBcc& move)
+ * @fn void FeatureExcludedVolumeBcc< LatticeClassType<LatticeValueType> >::applyMove(IngredientsType& ing, const MoveLocalBcc& move)
  * @brief Updates the lattice occupation according to the move for moves of type MoveLocalBcc. 
  * 
  * @param [in] ingredients A reference to the IngredientsType - mainly the system.
  * @param [in] move A reference to MoveLocalSBcc.
  * */
 /******************************************************************************/
-template<template<typename> class SpecializedClass, typename ValueType>
+template<template<typename> class LatticeClassType, typename LatticeValueType>
 template<class IngredientsType>
-void FeatureExcludedVolumeBcc< SpecializedClass<ValueType> >::applyMove(IngredientsType& ing, const MoveLocalBcc& move)
+void FeatureExcludedVolumeBcc< LatticeClassType<LatticeValueType> >::applyMove(IngredientsType& ing, const MoveLocalBcc& move)
 {
 	if (!latticeFilledUp)
 		throw std::runtime_error("*****FeatureExcludedVolumeBcc_T::applyMove....lattice is not populated. Run synchronize!\n");
@@ -256,16 +256,16 @@ void FeatureExcludedVolumeBcc< SpecializedClass<ValueType> >::applyMove(Ingredie
 
 /******************************************************************************/
 /**
- * @fn bool FeatureExcludedVolumeBcc< SpecializedClass<ValueType> >::checkMove( const IngredientsType& ingredients, const MoveAddBccMonomer& move )const
+ * @fn bool FeatureExcludedVolumeBcc< LatticeClassType<LatticeValueType> >::checkMove( const IngredientsType& ingredients, const MoveAddBccMonomer& move )const
  * @brief check excluded volume for insertion of a monomer on a bcc lattice
  * 
  * @param [in] ingredients A reference to the IngredientsType - mainly the system.
  * @param [in] move A reference to MoveAddBccMonomer.
  * */
 /******************************************************************************/
-template<template<typename> class SpecializedClass, typename ValueType>
+template<template<typename> class LatticeClassType, typename LatticeValueType>
 template < class IngredientsType>
-bool FeatureExcludedVolumeBcc< SpecializedClass<ValueType> >::checkMove( const IngredientsType& ingredients, const MoveAddBccMonomer& move ) const
+bool FeatureExcludedVolumeBcc< LatticeClassType<LatticeValueType> >::checkMove( const IngredientsType& ingredients, const MoveAddBccMonomer& move ) const
 {
   if (!latticeFilledUp)
 	throw std::runtime_error("*****FeatureExcludedVolume_T::checkMove....lattice is not populated. Run synchronize!\n");
@@ -310,16 +310,16 @@ bool FeatureExcludedVolumeBcc< SpecializedClass<ValueType> >::checkMove( const I
 
 /******************************************************************************/
 /**
- * @fn void FeatureExcludedVolumeBcc< SpecializedClass<ValueType> >::applyMove( const IngredientsType& ingredients, const MoveAddBccMonomer& move )const
+ * @fn void FeatureExcludedVolumeBcc< LatticeClassType<LatticeValueType> >::applyMove( const IngredientsType& ingredients, const MoveAddBccMonomer& move )const
  * @brief apply excluded volume for MoveAddBccMonomer.
  * 
  * @param [in] ingredients A reference to the IngredientsType - mainly the system.
  * @param [in] move A reference to MoveAddBccMonomer.
  * */
 /******************************************************************************/
-template<template<typename> class SpecializedClass, typename ValueType>
+template<template<typename> class LatticeClassType, typename LatticeValueType>
 template<class IngredientsType> 
-void FeatureExcludedVolumeBcc< SpecializedClass<ValueType> >::applyMove(IngredientsType& ing, const MoveAddBccMonomer& move)
+void FeatureExcludedVolumeBcc< LatticeClassType<LatticeValueType> >::applyMove(IngredientsType& ing, const MoveAddBccMonomer& move)
 {
   ing.setLatticeEntry(move.getPosition(),1);
 }
@@ -330,9 +330,9 @@ void FeatureExcludedVolumeBcc< SpecializedClass<ValueType> >::applyMove(Ingredie
  *
  * @param ingredients A reference to the IngredientsType - mainly the system.
  */
-template<template<typename> class SpecializedClass, typename ValueType>
+template<template<typename> class LatticeClassType, typename LatticeValueType>
 template<class IngredientsType>
-void FeatureExcludedVolumeBcc< SpecializedClass<ValueType> >::synchronize(
+void FeatureExcludedVolumeBcc< LatticeClassType<LatticeValueType> >::synchronize(
 		IngredientsType& ingredients)
 		{
 	//note: the lattice entries are set to 0 before by the 
@@ -351,9 +351,9 @@ void FeatureExcludedVolumeBcc< SpecializedClass<ValueType> >::synchronize(
  * @param ingredients A reference to the IngredientsType - mainly the system.
  */
 
-template<template<typename> class SpecializedClass, typename ValueType>
+template<template<typename> class LatticeClassType, typename LatticeValueType>
 template<class IngredientsType>
-void FeatureExcludedVolumeBcc< SpecializedClass<ValueType> >::fillLattice(
+void FeatureExcludedVolumeBcc< LatticeClassType<LatticeValueType> >::fillLattice(
 		IngredientsType& ingredients)
 		{
 	const typename IngredientsType::molecules_type& molecules =

--- a/include/LeMonADE/feature/FeatureExcludedVolumeSc.h
+++ b/include/LeMonADE/feature/FeatureExcludedVolumeSc.h
@@ -199,7 +199,9 @@ template<template<typename> class SpecializedClass, typename ValueType>
 template < class IngredientsType> 
 bool FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::checkMove( const IngredientsType& ingredients, const MoveLocalSc& move ) const
 {
-
+	if(!latticeFilledUp)
+	  throw std::runtime_error("*****FeatureExcludedVolumeSc_T::checkMove....lattice is not populated. Run synchronize!\n");
+	
 	//get the position of the monomer to be moved (assume "lower left corner")
 	VectorInt3 refPos=ingredients.getMolecules()[move.getIndex()];
 	//get the direction of the move

--- a/include/LeMonADE/feature/FeatureExcludedVolumeSc.h
+++ b/include/LeMonADE/feature/FeatureExcludedVolumeSc.h
@@ -35,6 +35,8 @@ along with LeMonADE.  If not, see <http://www.gnu.org/licenses/>.
 #include <LeMonADE/updater/moves/MoveBase.h>
 #include <LeMonADE/updater/moves/MoveLocalSc.h>
 #include <LeMonADE/updater/moves/MoveAddScMonomer.h>
+#include <LeMonADE/updater/moves/MoveLocalBcc.h>
+#include <LeMonADE/updater/moves/MoveAddBccMonomer.h>
 
 /*****************************************************************************/
 /**
@@ -115,9 +117,17 @@ public:
 	template<class IngredientsType>
 	bool checkMove(const IngredientsType& ingredients, const MoveLocalSc& move) const;
 	
+	//! check bcc move: Throw error if wrong lattice Type is used
+	template<class IngredientsType>
+	bool checkMove(const IngredientsType& ingredients, const MoveLocalBcc& move) const;
+	
 	//! check move for adding an sc monomer
 	template<class IngredientsType>
 	bool checkMove(const IngredientsType& ingredients, const MoveAddScMonomer& move) const;
+	
+	//! check bcc addmove: Throw error if wrong lattice Type is used
+	template<class IngredientsType>
+	bool checkMove(const IngredientsType& ingredients, const MoveAddBccMonomer& move) const;
 
 	//! apply move for basic moves - does nothing
 	template<class IngredientsType>
@@ -160,7 +170,6 @@ private:
  * @return true Always!
  */
 /******************************************************************************/
-//template<class  LatticeClassType<LatticeValueType> >
 template<template<typename> class LatticeClassType, typename LatticeValueType>
 template<class IngredientsType>
 bool FeatureExcludedVolumeSc< LatticeClassType<LatticeValueType> >::checkMove(const IngredientsType& ingredients, const MoveBase& move) const
@@ -187,6 +196,42 @@ void FeatureExcludedVolumeSc< LatticeClassType<LatticeValueType> >::applyMove(In
 
 /******************************************************************************/
 /**
+ * @fn bool FeatureExcludedVolumeSc< LatticeClassType<LatticeValueType> >::checkMove( const IngredientsType& ingredients, const MoveLocalBcc& move )const
+ * @brief Throws a runtime error because the lattice type is inconsitent with the move type
+ *
+ * @param [in] ingredients A reference to the IngredientsType - mainly the system
+ * @param [in] move MoveLocalBcc, which is the wrong one in this case
+ * @return false, throws an exception
+ */
+/******************************************************************************/
+template<template<typename> class LatticeClassType, typename LatticeValueType>
+template<class IngredientsType>
+bool FeatureExcludedVolumeSc< LatticeClassType<LatticeValueType> >::checkMove(const IngredientsType& ingredients, const MoveLocalBcc& move) const
+{
+	throw std::runtime_error("*****FeatureExcludedVolumeSc::check MoveLocalBcc: wrong lattice type ... \n");
+	return false;
+}
+
+/******************************************************************************/
+/**
+ * @fn bool FeatureExcludedVolumeSc< LatticeClassType<LatticeValueType> >::checkMove( const IngredientsType& ingredients, const MoveAddBccMonomer& addmove )const
+ * @brief Throws a runtime error because the lattice type is inconsitent with the move type
+ *
+ * @param [in] ingredients A reference to the IngredientsType - mainly the system
+ * @param [in] move MoveAddBccMonomer, which is the wrong one in this case
+ * @return false, throws an exception
+ */
+/******************************************************************************/
+template<template<typename> class LatticeClassType, typename LatticeValueType>
+template<class IngredientsType>
+bool FeatureExcludedVolumeSc< LatticeClassType<LatticeValueType> >::checkMove(const IngredientsType& ingredients, const MoveAddBccMonomer& addmove) const
+{
+	throw std::runtime_error("*****FeatureExcludedVolumeSc::check MoveAddBccMonomer: wrong lattice type ... \n");
+	return false;
+}
+
+/******************************************************************************/
+/**
  * @fn bool FeatureExcludedVolumeSc< LatticeClassType<LatticeValueType> >::checkMove( const IngredientsType& ingredients, const MoveLocalSc& move )const
  * @brief checks excluded volume for moves of type MoveLocalSc
  * 
@@ -200,7 +245,7 @@ template < class IngredientsType>
 bool FeatureExcludedVolumeSc< LatticeClassType<LatticeValueType> >::checkMove( const IngredientsType& ingredients, const MoveLocalSc& move ) const
 {
 	if(!latticeFilledUp)
-	  throw std::runtime_error("*****FeatureExcludedVolumeSc_T::checkMove....lattice is not populated. Run synchronize!\n");
+	  throw std::runtime_error("*****FeatureExcludedVolumeSc::checkMove....lattice is not populated. Run synchronize!\n");
 	
 	//get the position of the monomer to be moved (assume "lower left corner")
 	VectorInt3 refPos=ingredients.getMolecules()[move.getIndex()];
@@ -304,7 +349,7 @@ template < class IngredientsType>
 bool FeatureExcludedVolumeSc< LatticeClassType<LatticeValueType> >::checkMove( const IngredientsType& ingredients, const MoveAddScMonomer& move ) const
 {
   if (!latticeFilledUp)
-	throw std::runtime_error("*****FeatureExcludedVolume_T::checkMove....lattice is not populated. Run synchronize!\n");
+	throw std::runtime_error("*****FeatureExcludedVolumeSc::checkMove....lattice is not populated. Run synchronize!\n");
   
   //check if the lattice sites are free
   VectorInt3 pos=move.getPosition();
@@ -370,7 +415,7 @@ void FeatureExcludedVolumeSc< LatticeClassType<LatticeValueType> >::synchronize(
 {
 	//note: the lattice entries are set to 0 before by the 
 	//synchronize function of FeatureLattice
-	std::cout << "FeatureExcludedVolumeSc_T::synchronizing lattice occupation...\n";
+	std::cout << "FeatureExcludedVolumeSc::synchronizing lattice occupation...\n";
 	fillLattice(ingredients);
 	std::cout << "done\n";
 }

--- a/include/LeMonADE/feature/FeatureExcludedVolumeSc.h
+++ b/include/LeMonADE/feature/FeatureExcludedVolumeSc.h
@@ -1,0 +1,422 @@
+/*--------------------------------------------------------------------------------
+    ooo      L   attice-based  |
+  o\.|./o    e   xtensible     | LeMonADE: An Open Source Implementation of the
+ o\.\|/./o   Mon te-Carlo      |           Bond-Fluctuation-Model for Polymers
+oo---0---oo  A   lgorithm and  |
+ o/./|\.\o   D   evelopment    | Copyright (C) 2013-2015 by 
+  o/.|.\o    E   nvironment    | LeMonADE Principal Developers (see AUTHORS)
+    ooo                        | 
+----------------------------------------------------------------------------------
+
+This file is part of LeMonADE.
+
+LeMonADE is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+LeMonADE is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with LeMonADE.  If not, see <http://www.gnu.org/licenses/>.
+
+--------------------------------------------------------------------------------*/
+
+#ifndef LEMONADE_FEATURE_FEATUREEXCLUDEDVOLUMESC_H
+#define LEMONADE_FEATURE_FEATUREEXCLUDEDVOLUMESC_H
+
+#include <LeMonADE/feature/Feature.h>
+#include <LeMonADE/feature/FeatureLattice.h>
+#include <LeMonADE/feature/FeatureLatticePowerOfTwo.h>
+
+#include <LeMonADE/updater/moves/MoveBase.h>
+#include <LeMonADE/updater/moves/MoveLocalSc.h>
+#include <LeMonADE/updater/moves/MoveAddScMonomer.h>
+
+/*****************************************************************************/
+/**
+ * @file
+ * @date   2016/02/18
+ * @author Hauke
+ *
+ * @class FeatureExcludedVolumeSc
+ * @brief This Feature adds excluded volume check to the system.
+ * It is specialised to the simple cubic lattice.
+ * 
+ * @details The excluded volume is checked by a lattice occupation algorithm
+ * on a simple cubic lattice.
+ * The feature is implemented as a class template, where the template parameters 
+ * \a SpecializedClass and \a ValueTypes specify, what
+ * type of lattice is used and which kind of value is saved on the lattice.
+ * This feature requires FeatureLattice.
+ * Notice: only implementations of Sc moves included to avoid a mix of 
+ * FeatureExcludedVolumeSc and MoveLocalBcc.
+ *
+ * @tparam <SpecializedClass<ValueType>> name of the specialized class.
+ * Default is FeatureLattice.
+ * 
+ * @tparam <ValueType> type of the lattice value. Default is bool.
+ * */
+/*****************************************************************************/
+
+/**
+ * @brief Forward declaration. Equivalent to FeatureExcludedVolumeSc< FeatureLattice <bool> >
+ */
+template<class SpecializedClass = FeatureLattice<> > class FeatureExcludedVolumeSc;
+
+///////////////////////////////////////////////////////////////////////////////
+//DEFINITION OF THE CLASS TEMPLATE   	                                ///////
+//Implementation of the members below					///////
+///////////////////////////////////////////////////////////////////////////////
+
+template<template<typename> class SpecializedClass, typename ValueType>
+class FeatureExcludedVolumeSc< SpecializedClass<ValueType> > : public Feature {
+public:
+	//! This Feature requires a lattice.
+	typedef LOKI_TYPELIST_1(SpecializedClass<ValueType>) required_features_front;
+
+	//constructor
+	FeatureExcludedVolumeSc() :
+			latticeFilledUp(false) 
+	{
+	}
+
+	/**
+	 * Returns true if the underlying lattice is synchronized and all excluded volume condition
+	 * (e.g. monomer/vertex occupies lattice edges) is applied.
+	 * Returns false if this feature is out-of-sync.
+	 *
+	 * @return true if this feature is synchronized
+	 * 		   false if this feature is out-of-sync.
+	 **/
+	bool isLatticeFilledUp() const {
+		return latticeFilledUp;
+	}
+
+	/**
+	 * Set's the need of synchronization of this feature e.g. escp. if the underlying lattice needs
+	 * to refilled and if all excluded volume condition needs to be updated.
+	 *
+	 * @param[in] latticeFilledUp Specified if ExVol should be refilled (false) or everything is in-sync (true).
+	 *
+	 **/
+	void setLatticeFilledUp(bool latticeFilledUp) {
+		this->latticeFilledUp = latticeFilledUp;
+	}
+
+	//! check move for basic move - always true
+	template<class IngredientsType>
+	bool checkMove(const IngredientsType& ingredients, const MoveBase& move) const;
+	
+	//! check move for sc local move
+	template<class IngredientsType>
+	bool checkMove(const IngredientsType& ingredients, const MoveLocalSc& move) const;
+	
+	//! check move for adding an sc monomer
+	template<class IngredientsType>
+	bool checkMove(const IngredientsType& ingredients, const MoveAddScMonomer& move) const;
+
+	//! apply move for basic moves - does nothing
+	template<class IngredientsType>
+	void applyMove(IngredientsType& ing, const MoveBase& move);
+
+	//! apply move for local sc moves
+	template<class IngredientsType>
+	void applyMove(IngredientsType& ing, const MoveLocalSc& move);
+	
+	//! apply move for adding an sc monomer
+	template<class IngredientsType>
+	void applyMove(IngredientsType& ing, const MoveAddScMonomer& move);
+
+	//! Synchronize with system: Fill the lattice with 1 (occupied) and 0 (free).
+	template<class IngredientsType>
+	void synchronize(IngredientsType& ingredients);
+
+private:
+
+	//! Populates the lattice using the coordinates of molecules.
+	template<class IngredientsType> void fillLattice(
+			IngredientsType& ingredients);
+
+	//! Tag for indication if the lattice is populated.
+	bool latticeFilledUp;
+
+};
+
+///////////////////////////////////////////////////////////////////////////////
+////////////////////////// member definitions /////////////////////////////////
+
+/******************************************************************************/
+/**
+ * @fn bool FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::checkMove( const IngredientsType& ingredients, const MoveBase& move )const
+ * @brief Returns true for all moves other than the ones that have specialized versions of this function.
+ * This dummy function is implemented for generality.
+ *
+ * @param [in] ingredients A reference to the IngredientsType - mainly the system
+ * @param [in] move General move other than MoveLocalSc or MoveLocalBcc.
+ * @return true Always!
+ */
+/******************************************************************************/
+//template<class  SpecializedClass<ValueType> >
+template<template<typename> class SpecializedClass, typename ValueType>
+template<class IngredientsType>
+bool FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::checkMove(const IngredientsType& ingredients, const MoveBase& move) const
+{
+	return true;
+}
+
+/******************************************************************************/
+/**
+ * @fn void FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::applyMove(IngredientsType& ing, const MoveBase& move)
+ * @brief This function applies for unknown moves other than the ones that have specialized versions of this function.
+ * It does nothing and is implemented for generality.
+ *
+ * @param [in] ingredients A reference to the IngredientsType - mainly the system
+ * @param [in] move General move other than MoveLocalSc or MoveLocalBcc.
+ */
+/******************************************************************************/
+template<template<typename> class SpecializedClass, typename ValueType>
+template<class IngredientsType>
+void FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::applyMove(IngredientsType& ing,const MoveBase& move)
+{
+
+}
+
+/******************************************************************************/
+/**
+ * @fn bool FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::checkMove( const IngredientsType& ingredients, const MoveLocalSc& move )const
+ * @brief checks excluded volume for moves of type MoveLocalSc
+ * 
+ * @param [in] ingredients A reference to the IngredientsType - mainly the system.
+ * @param [in] move A reference to MoveLocalSc.
+ * @return if move is allowed (\a true) or rejected (\a false).
+ * */
+/******************************************************************************/
+template<template<typename> class SpecializedClass, typename ValueType>
+template < class IngredientsType> 
+bool FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::checkMove( const IngredientsType& ingredients, const MoveLocalSc& move ) const
+{
+
+	//get the position of the monomer to be moved (assume "lower left corner")
+	VectorInt3 refPos=ingredients.getMolecules()[move.getIndex()];
+	//get the direction of the move
+	VectorInt3 direction=move.getDir();
+
+	//shift refPos in the direction of the move. this defines then the 
+	//point around which the volume occupation must be checked
+	if(direction.getX()>0 || direction.getY()>0 || direction.getZ()>0) refPos+=direction;
+	refPos+=direction; 
+	
+	//now the nine closest positions in the plane of refPos perpendicular to the 
+	//move direction must be checked
+	
+	/*get two directions perpendicular to vector directon of the move*/
+	VectorInt3 perp1,perp2;
+  	/* first perpendicular direction is either (0 1 0) or (1 0 0)*/
+	int32_t x1=((direction.getX()==0) ? 1 : 0);
+	int32_t y1=((direction.getX()!=0) ? 1 : 0);
+	perp1.setX(x1);
+	perp1.setY(y1);
+	perp1.setZ(0);
+	
+	/* second perpendicular direction is either (0 0 1) or (0 1 0)*/
+	int32_t y2=((direction.getZ()==0) ? 0 : 1);
+	int32_t z2=((direction.getZ()!=0) ? 0 : 1);
+	perp2.setX(0);
+	perp2.setY(y2);
+	perp2.setZ(z2);
+	
+
+    //check if the lattice sites are free
+    if	(
+            (ingredients.getLatticeEntry(refPos))||
+            (ingredients.getLatticeEntry(refPos+perp1))||
+            (ingredients.getLatticeEntry(refPos+perp2))||
+            (ingredients.getLatticeEntry(refPos+perp1+perp2))
+            ) return false;
+    else return true;
+
+}
+
+/******************************************************************************/
+/**
+ * @fn void FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::applyMove(IngredientsType& ing, const MoveLocalSc<LocalMoveType>& move)
+ * @brief Updates the lattice occupation according to the move for moves of type MoveLocalSc. 
+ * 
+ * @param [in] ingredients A reference to the IngredientsType - mainly the system.
+ * @param [in] move A reference to MoveLocalSc.
+ * */
+/******************************************************************************/
+template<template<typename> class SpecializedClass, typename ValueType>
+template<class IngredientsType> 
+void FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::applyMove(IngredientsType& ing, const MoveLocalSc& move)
+{
+	//get old position and direction of the move
+	VectorInt3 oldPos=ing.getMolecules()[move.getIndex()];
+	VectorInt3 direction=move.getDir();	
+	
+	/*get two directions perpendicular to vector directon of the move*/
+	VectorInt3 perp1,perp2;
+  	/* first perpendicular direction is either (0 1 0) or (1 0 0)*/
+	int32_t x1=((direction.getX()==0) ? 1 : 0);
+	int32_t y1=((direction.getX()!=0) ? 1 : 0);
+	perp1.setX(x1);
+	perp1.setY(y1);
+	perp1.setZ(0);
+	
+	/* second perpendicular direction is either (0 0 1) or (0 1 0)*/
+	int32_t y2=((direction.getZ()==0) ? 0 : 1);
+	int32_t z2=((direction.getZ()!=0) ? 0 : 1);
+	perp2.setX(0);
+	perp2.setY(y2);
+	perp2.setZ(z2);
+	
+	
+	if(direction.getX()<0 || direction.getY()<0 || direction.getZ()<0) oldPos-=direction;
+	direction*=2;
+	
+    VectorInt3 oldPlusDir=oldPos+direction;
+	//change lattice occupation accordingly
+    ing.moveOnLattice(oldPos,oldPlusDir);
+    ing.moveOnLattice(oldPos+perp1,oldPlusDir+perp1);
+    ing.moveOnLattice(oldPos+perp2,oldPlusDir+perp2);
+    ing.moveOnLattice(oldPos+perp1+perp2,oldPlusDir+perp1+perp2);
+	
+}
+
+
+/******************************************************************************/
+/**
+ * @fn bool FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::checkMove( const IngredientsType& ingredients, const MoveAddScMonomer& move )const
+ * @brief check excluded volume for insertion of a monomer on a sc lattice
+ * 
+ * @param [in] ingredients A reference to the IngredientsType - mainly the system.
+ * @param [in] move A reference to MoveAddScMonomer.
+ * */
+/******************************************************************************/
+template<template<typename> class SpecializedClass, typename ValueType>
+template < class IngredientsType>
+bool FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::checkMove( const IngredientsType& ingredients, const MoveAddScMonomer& move ) const
+{
+  if (!latticeFilledUp)
+	throw std::runtime_error("*****FeatureExcludedVolume_T::checkMove....lattice is not populated. Run synchronize!\n");
+  
+  //check if the lattice sites are free
+  VectorInt3 pos=move.getPosition();
+  VectorInt3 dx(1,0,0);
+  VectorInt3 dy(0,1,0);
+  VectorInt3 dz(0,0,1);
+
+  if	(
+	 (ingredients.getLatticeEntry(pos))||
+	 (ingredients.getLatticeEntry(pos+dx))||
+	 (ingredients.getLatticeEntry(pos+dy))||
+	 (ingredients.getLatticeEntry(pos+dx+dy))||
+	 (ingredients.getLatticeEntry(pos+dz))||
+	 (ingredients.getLatticeEntry(pos+dz+dx))||
+	 (ingredients.getLatticeEntry(pos+dz+dy))||
+	 (ingredients.getLatticeEntry(pos+dz+dx+dy))
+	 ) return false;
+  else 
+    return true;
+}
+
+
+/******************************************************************************/
+/**
+ * @fn void FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::applyMove( const IngredientsType& ingredients, const MoveAddScMonomer& move )const
+ * @brief apply excluded volume for MoveAddScMonomer.
+ * 
+ * @param [in] ingredients A reference to the IngredientsType - mainly the system.
+ * @param [in] move A reference to MoveAddScMonomer.
+ * */
+/******************************************************************************/
+template<template<typename> class SpecializedClass, typename ValueType>
+template<class IngredientsType> 
+void FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::applyMove(IngredientsType& ing, const MoveAddScMonomer& move)
+{
+  VectorInt3 pos=move.getPosition();
+  VectorInt3 dx(1,0,0);
+  VectorInt3 dy(0,1,0);
+  VectorInt3 dz(0,0,1);
+
+  ing.setLatticeEntry(pos,1);
+  ing.setLatticeEntry(pos+dx,1);
+  ing.setLatticeEntry(pos+dy,1);
+  ing.setLatticeEntry(pos+dx+dy,1);
+  ing.setLatticeEntry(pos+dz,1);
+  ing.setLatticeEntry(pos+dz+dx,1);
+  ing.setLatticeEntry(pos+dz+dy,1);
+  ing.setLatticeEntry(pos+dz+dx+dy,1);
+}
+
+/******************************************************************************/
+/**
+ * @fn void FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::synchronize(IngredientsType& ingredients)
+ * @brief Synchronizes the lattice occupation with the rest of the system 
+ * by calling the private function fillLattice.
+ *
+ * @param ingredients A reference to the IngredientsType - mainly the system.
+ */
+/******************************************************************************/
+template<template<typename> class SpecializedClass, typename ValueType>
+template<class IngredientsType>
+void FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::synchronize(IngredientsType& ingredients)
+{
+	//note: the lattice entries are set to 0 before by the 
+	//synchronize function of FeatureLattice
+	std::cout << "FeatureExcludedVolumeSc_T::synchronizing lattice occupation...\n";
+	fillLattice(ingredients);
+	std::cout << "done\n";
+}
+
+/******************************************************************************/
+/**
+ * @fn void FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::fillLattice(IngredientsType& ingredients)
+ * @brief This function populates the lattice directly with positions from molecules.
+ * It also has a simple check if the target lattice is already occupied.
+ * 
+ * @param ingredients A reference to the IngredientsType - mainly the system.
+ * */
+/******************************************************************************/
+template<template<typename> class SpecializedClass, typename ValueType>
+template<class IngredientsType> 
+void FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::fillLattice(IngredientsType& ingredients)
+{
+	const typename IngredientsType::molecules_type& molecules=ingredients.getMolecules();
+	//copy the lattice occupation from the monomer coordinates
+	for(size_t n=0;n<molecules.size();n++)
+	{
+
+		if( ingredients.getLatticeEntry(molecules[n])!=0 )
+		{
+			throw std::runtime_error("********** FeatureExcludedVolume::fillLattice: multiple lattice occupation ******************");
+		}
+		else
+		{
+			//here we simply set a one on every occupied lattice
+			//site. this assumes that 1 can be cast to  SpecializedClass<ValueType> ,
+			//even though in principle  SpecializedClass<ValueType>  could be anything.
+			//note that this may be just a preliminiary initialization,
+			//as other features may assign more specific values to the
+			//lattice site.
+			VectorInt3 pos=molecules[n];
+			
+			ingredients.setLatticeEntry(pos,1);
+			ingredients.setLatticeEntry(pos+VectorInt3(1,0,0),1);
+			ingredients.setLatticeEntry(pos+VectorInt3(0,1,0),1);
+			ingredients.setLatticeEntry(pos+VectorInt3(1,1,0),1);
+			ingredients.setLatticeEntry(pos+VectorInt3(0,0,1),1);
+			ingredients.setLatticeEntry(pos+VectorInt3(1,0,1),1);
+			ingredients.setLatticeEntry(pos+VectorInt3(0,1,1),1);
+			ingredients.setLatticeEntry(pos+VectorInt3(1,1,1),1);
+		}
+				
+	}
+	latticeFilledUp=true;
+}
+
+#endif

--- a/include/LeMonADE/feature/FeatureExcludedVolumeSc.h
+++ b/include/LeMonADE/feature/FeatureExcludedVolumeSc.h
@@ -49,34 +49,34 @@ along with LeMonADE.  If not, see <http://www.gnu.org/licenses/>.
  * @details The excluded volume is checked by a lattice occupation algorithm
  * on a simple cubic lattice.
  * The feature is implemented as a class template, where the template parameters 
- * \a SpecializedClass and \a ValueTypes specify, what
+ * \a LatticeClassType and \a LatticeValueTypes specify, what
  * type of lattice is used and which kind of value is saved on the lattice.
  * This feature requires FeatureLattice.
  * Notice: only implementations of Sc moves included to avoid a mix of 
  * FeatureExcludedVolumeSc and MoveLocalBcc.
  *
- * @tparam <SpecializedClass<ValueType>> name of the specialized class.
+ * @tparam <LatticeClassType<LatticeValueType>> name of the specialized class.
  * Default is FeatureLattice.
  * 
- * @tparam <ValueType> type of the lattice value. Default is bool.
+ * @tparam <LatticeValueType> type of the lattice value. Default is bool.
  * */
 /*****************************************************************************/
 
 /**
  * @brief Forward declaration. Equivalent to FeatureExcludedVolumeSc< FeatureLattice <bool> >
  */
-template<class SpecializedClass = FeatureLattice<> > class FeatureExcludedVolumeSc;
+template<class LatticeClassType = FeatureLattice<> > class FeatureExcludedVolumeSc;
 
 ///////////////////////////////////////////////////////////////////////////////
 //DEFINITION OF THE CLASS TEMPLATE   	                                ///////
 //Implementation of the members below					///////
 ///////////////////////////////////////////////////////////////////////////////
 
-template<template<typename> class SpecializedClass, typename ValueType>
-class FeatureExcludedVolumeSc< SpecializedClass<ValueType> > : public Feature {
+template<template<typename> class LatticeClassType, typename LatticeValueType>
+class FeatureExcludedVolumeSc< LatticeClassType<LatticeValueType> > : public Feature {
 public:
 	//! This Feature requires a lattice.
-	typedef LOKI_TYPELIST_1(SpecializedClass<ValueType>) required_features_front;
+	typedef LOKI_TYPELIST_1(LatticeClassType<LatticeValueType>) required_features_front;
 
 	//constructor
 	FeatureExcludedVolumeSc() :
@@ -151,7 +151,7 @@ private:
 
 /******************************************************************************/
 /**
- * @fn bool FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::checkMove( const IngredientsType& ingredients, const MoveBase& move )const
+ * @fn bool FeatureExcludedVolumeSc< LatticeClassType<LatticeValueType> >::checkMove( const IngredientsType& ingredients, const MoveBase& move )const
  * @brief Returns true for all moves other than the ones that have specialized versions of this function.
  * This dummy function is implemented for generality.
  *
@@ -160,17 +160,17 @@ private:
  * @return true Always!
  */
 /******************************************************************************/
-//template<class  SpecializedClass<ValueType> >
-template<template<typename> class SpecializedClass, typename ValueType>
+//template<class  LatticeClassType<LatticeValueType> >
+template<template<typename> class LatticeClassType, typename LatticeValueType>
 template<class IngredientsType>
-bool FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::checkMove(const IngredientsType& ingredients, const MoveBase& move) const
+bool FeatureExcludedVolumeSc< LatticeClassType<LatticeValueType> >::checkMove(const IngredientsType& ingredients, const MoveBase& move) const
 {
 	return true;
 }
 
 /******************************************************************************/
 /**
- * @fn void FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::applyMove(IngredientsType& ing, const MoveBase& move)
+ * @fn void FeatureExcludedVolumeSc< LatticeClassType<LatticeValueType> >::applyMove(IngredientsType& ing, const MoveBase& move)
  * @brief This function applies for unknown moves other than the ones that have specialized versions of this function.
  * It does nothing and is implemented for generality.
  *
@@ -178,16 +178,16 @@ bool FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::checkMove(const Ing
  * @param [in] move General move other than MoveLocalSc or MoveLocalBcc.
  */
 /******************************************************************************/
-template<template<typename> class SpecializedClass, typename ValueType>
+template<template<typename> class LatticeClassType, typename LatticeValueType>
 template<class IngredientsType>
-void FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::applyMove(IngredientsType& ing,const MoveBase& move)
+void FeatureExcludedVolumeSc< LatticeClassType<LatticeValueType> >::applyMove(IngredientsType& ing,const MoveBase& move)
 {
 
 }
 
 /******************************************************************************/
 /**
- * @fn bool FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::checkMove( const IngredientsType& ingredients, const MoveLocalSc& move )const
+ * @fn bool FeatureExcludedVolumeSc< LatticeClassType<LatticeValueType> >::checkMove( const IngredientsType& ingredients, const MoveLocalSc& move )const
  * @brief checks excluded volume for moves of type MoveLocalSc
  * 
  * @param [in] ingredients A reference to the IngredientsType - mainly the system.
@@ -195,9 +195,9 @@ void FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::applyMove(Ingredien
  * @return if move is allowed (\a true) or rejected (\a false).
  * */
 /******************************************************************************/
-template<template<typename> class SpecializedClass, typename ValueType>
+template<template<typename> class LatticeClassType, typename LatticeValueType>
 template < class IngredientsType> 
-bool FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::checkMove( const IngredientsType& ingredients, const MoveLocalSc& move ) const
+bool FeatureExcludedVolumeSc< LatticeClassType<LatticeValueType> >::checkMove( const IngredientsType& ingredients, const MoveLocalSc& move ) const
 {
 	if(!latticeFilledUp)
 	  throw std::runtime_error("*****FeatureExcludedVolumeSc_T::checkMove....lattice is not populated. Run synchronize!\n");
@@ -245,16 +245,16 @@ bool FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::checkMove( const In
 
 /******************************************************************************/
 /**
- * @fn void FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::applyMove(IngredientsType& ing, const MoveLocalSc<LocalMoveType>& move)
+ * @fn void FeatureExcludedVolumeSc< LatticeClassType<LatticeValueType> >::applyMove(IngredientsType& ing, const MoveLocalSc<LocalMoveType>& move)
  * @brief Updates the lattice occupation according to the move for moves of type MoveLocalSc. 
  * 
  * @param [in] ingredients A reference to the IngredientsType - mainly the system.
  * @param [in] move A reference to MoveLocalSc.
  * */
 /******************************************************************************/
-template<template<typename> class SpecializedClass, typename ValueType>
+template<template<typename> class LatticeClassType, typename LatticeValueType>
 template<class IngredientsType> 
-void FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::applyMove(IngredientsType& ing, const MoveLocalSc& move)
+void FeatureExcludedVolumeSc< LatticeClassType<LatticeValueType> >::applyMove(IngredientsType& ing, const MoveLocalSc& move)
 {
 	//get old position and direction of the move
 	VectorInt3 oldPos=ing.getMolecules()[move.getIndex()];
@@ -292,16 +292,16 @@ void FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::applyMove(Ingredien
 
 /******************************************************************************/
 /**
- * @fn bool FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::checkMove( const IngredientsType& ingredients, const MoveAddScMonomer& move )const
+ * @fn bool FeatureExcludedVolumeSc< LatticeClassType<LatticeValueType> >::checkMove( const IngredientsType& ingredients, const MoveAddScMonomer& move )const
  * @brief check excluded volume for insertion of a monomer on a sc lattice
  * 
  * @param [in] ingredients A reference to the IngredientsType - mainly the system.
  * @param [in] move A reference to MoveAddScMonomer.
  * */
 /******************************************************************************/
-template<template<typename> class SpecializedClass, typename ValueType>
+template<template<typename> class LatticeClassType, typename LatticeValueType>
 template < class IngredientsType>
-bool FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::checkMove( const IngredientsType& ingredients, const MoveAddScMonomer& move ) const
+bool FeatureExcludedVolumeSc< LatticeClassType<LatticeValueType> >::checkMove( const IngredientsType& ingredients, const MoveAddScMonomer& move ) const
 {
   if (!latticeFilledUp)
 	throw std::runtime_error("*****FeatureExcludedVolume_T::checkMove....lattice is not populated. Run synchronize!\n");
@@ -329,16 +329,16 @@ bool FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::checkMove( const In
 
 /******************************************************************************/
 /**
- * @fn void FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::applyMove( const IngredientsType& ingredients, const MoveAddScMonomer& move )const
+ * @fn void FeatureExcludedVolumeSc< LatticeClassType<LatticeValueType> >::applyMove( const IngredientsType& ingredients, const MoveAddScMonomer& move )const
  * @brief apply excluded volume for MoveAddScMonomer.
  * 
  * @param [in] ingredients A reference to the IngredientsType - mainly the system.
  * @param [in] move A reference to MoveAddScMonomer.
  * */
 /******************************************************************************/
-template<template<typename> class SpecializedClass, typename ValueType>
+template<template<typename> class LatticeClassType, typename LatticeValueType>
 template<class IngredientsType> 
-void FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::applyMove(IngredientsType& ing, const MoveAddScMonomer& move)
+void FeatureExcludedVolumeSc< LatticeClassType<LatticeValueType> >::applyMove(IngredientsType& ing, const MoveAddScMonomer& move)
 {
   VectorInt3 pos=move.getPosition();
   VectorInt3 dx(1,0,0);
@@ -357,16 +357,16 @@ void FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::applyMove(Ingredien
 
 /******************************************************************************/
 /**
- * @fn void FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::synchronize(IngredientsType& ingredients)
+ * @fn void FeatureExcludedVolumeSc< LatticeClassType<LatticeValueType> >::synchronize(IngredientsType& ingredients)
  * @brief Synchronizes the lattice occupation with the rest of the system 
  * by calling the private function fillLattice.
  *
  * @param ingredients A reference to the IngredientsType - mainly the system.
  */
 /******************************************************************************/
-template<template<typename> class SpecializedClass, typename ValueType>
+template<template<typename> class LatticeClassType, typename LatticeValueType>
 template<class IngredientsType>
-void FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::synchronize(IngredientsType& ingredients)
+void FeatureExcludedVolumeSc< LatticeClassType<LatticeValueType> >::synchronize(IngredientsType& ingredients)
 {
 	//note: the lattice entries are set to 0 before by the 
 	//synchronize function of FeatureLattice
@@ -377,31 +377,40 @@ void FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::synchronize(Ingredi
 
 /******************************************************************************/
 /**
- * @fn void FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::fillLattice(IngredientsType& ingredients)
+ * @fn void FeatureExcludedVolumeSc< LatticeClassType<LatticeValueType> >::fillLattice(IngredientsType& ingredients)
  * @brief This function populates the lattice directly with positions from molecules.
  * It also has a simple check if the target lattice is already occupied.
  * 
  * @param ingredients A reference to the IngredientsType - mainly the system.
  * */
 /******************************************************************************/
-template<template<typename> class SpecializedClass, typename ValueType>
+template<template<typename> class LatticeClassType, typename LatticeValueType>
 template<class IngredientsType> 
-void FeatureExcludedVolumeSc< SpecializedClass<ValueType> >::fillLattice(IngredientsType& ingredients)
+void FeatureExcludedVolumeSc< LatticeClassType<LatticeValueType> >::fillLattice(IngredientsType& ingredients)
 {
 	const typename IngredientsType::molecules_type& molecules=ingredients.getMolecules();
 	//copy the lattice occupation from the monomer coordinates
 	for(size_t n=0;n<molecules.size();n++)
 	{
+		VectorInt3 pos=ingredients.getMolecules()[n];
 
-		if( ingredients.getLatticeEntry(molecules[n])!=0 )
+		if( ingredients.getLatticeEntry(pos)!=0 ||
+		  ingredients.getLatticeEntry(pos+VectorInt3(1,0,0))!=0 ||
+		  ingredients.getLatticeEntry(pos+VectorInt3(0,1,0))!=0 ||
+		  ingredients.getLatticeEntry(pos+VectorInt3(0,0,1))!=0 ||
+		  ingredients.getLatticeEntry(pos+VectorInt3(1,1,0))!=0 ||
+		  ingredients.getLatticeEntry(pos+VectorInt3(1,0,1))!=0 ||
+		  ingredients.getLatticeEntry(pos+VectorInt3(0,1,1))!=0 ||
+		  ingredients.getLatticeEntry(pos+VectorInt3(1,1,1))!=0
+		)
 		{
 			throw std::runtime_error("********** FeatureExcludedVolume::fillLattice: multiple lattice occupation ******************");
 		}
 		else
 		{
 			//here we simply set a one on every occupied lattice
-			//site. this assumes that 1 can be cast to  SpecializedClass<ValueType> ,
-			//even though in principle  SpecializedClass<ValueType>  could be anything.
+			//site. this assumes that 1 can be cast to  LatticeClassType<LatticeValueType> ,
+			//even though in principle  LatticeClassType<LatticeValueType>  could be anything.
 			//note that this may be just a preliminiary initialization,
 			//as other features may assign more specific values to the
 			//lattice site.

--- a/include/LeMonADE/updater/moves/MoveAddBccMonomer.h
+++ b/include/LeMonADE/updater/moves/MoveAddBccMonomer.h
@@ -1,0 +1,124 @@
+/*--------------------------------------------------------------------------------
+    ooo      L   attice-based  |
+  o\.|./o    e   xtensible     | LeMonADE: An Open Source Implementation of the
+ o\.\|/./o   Mon te-Carlo      |           Bond-Fluctuation-Model for Polymers
+oo---0---oo  A   lgorithm and  |
+ o/./|\.\o   D   evelopment    | Copyright (C) 2013-2015 by 
+  o/.|.\o    E   nvironment    | LeMonADE Principal Developers (see AUTHORS)
+    ooo                        | 
+----------------------------------------------------------------------------------
+
+This file is part of LeMonADE.
+
+LeMonADE is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+LeMonADE is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with LeMonADE.  If not, see <http://www.gnu.org/licenses/>.
+
+--------------------------------------------------------------------------------*/
+
+#ifndef LEMONADE_UPDATER_MOVES_MOVEADDBCCMONOMER_H
+#define LEMONADE_UPDATER_MOVES_MOVEADDBCCMONOMER_H
+
+#include <LeMonADE/updater/moves/MoveBase.h>
+
+/**
+ * @file
+ * @date   2016/03/14
+ * @author Martin
+ * @class MoveAddBccMonomer
+ *
+ * @brief Add monomer move for the bccBFM to add a vertex/monomer
+ *
+ * @todo Code doubling with MoveAddScMonomer! Specialized class only neccessary to enable the features to handle the moves types differently.
+ **/
+class MoveAddBccMonomer:public MoveBase
+{
+public:
+  
+  //! Reset the probability
+  template <class IngredientsType> void init(const IngredientsType& ing);
+
+  //! Check if the move is allowed by the system given as argument.
+  template <class IngredientsType> bool check(IngredientsType& ing);
+
+  //! Apply the move to the system given as argument
+  template< class IngredientsType> void apply(IngredientsType& ing);
+  
+  //! setter function for type of new monomer
+  void setType(int32_t t){type=t;}
+  //! setter function for position of new monomer taking a VectorInt3
+  void setPosition(VectorInt3 pos){position=pos;}
+  //! setter function for position of new monomer taking a triple of ints
+  void setPosition(int32_t x,int32_t y,int32_t z){position.setX(x);position.setY(y);position.setZ(z);}
+  //! getter function for the type of the new monomer
+  int32_t getType() const{return type;}
+  //! getter function for the position of the new monomer returning a VectorInt3
+  const VectorInt3 getPosition() const {return position;}
+  //! getter function for index of the new monomer. This is ing.getMolecules().size() before applying and ing.getMolecules().size()-1 after applying the move.
+  size_t getParticleIndex() const {return particleIndex;}
+  
+private:
+  //! position where the new monomer is placed in the simulation box
+  VectorInt3 position;
+  //! type that is applied to the new monomer, requires Feature FeatureAttributes with int-Type
+  int32_t type;
+  /** 
+   * @brief Index of new PartileThis is ing.getMolecules().size() before applying and ing.getMolecules().size()-1 after applying the move.
+   * @details It is set when apply is called. useful if Features want to alter the particle when applying the move
+   */
+  size_t particleIndex;
+};
+
+
+
+/////////////////////////////////////////////////////////////////////////////
+/////////// implementation of the members ///////////////////////////////////
+
+/*****************************************************************************/
+/**
+ * @brief reset the probability and calculate particle index
+ */
+template <class IngredientsType>
+void MoveAddBccMonomer::init(const IngredientsType& ing)
+{
+    this->resetProbability();
+    particleIndex=ing.getMolecules().size();
+}
+
+/*****************************************************************************/
+/**
+ * @brief check if the move is allowed by the system given as argument.
+ */
+template <class IngredientsType>
+bool MoveAddBccMonomer::check(IngredientsType& ing)
+{
+  //send the move to the Features to be checked
+  return ing.checkMove(ing,*this);
+}
+  
+/*****************************************************************************/
+/**
+ * @brief apply the move to the system given as argument
+ */
+template< class IngredientsType>
+void MoveAddBccMonomer::apply(IngredientsType& ing)
+{
+  //first add the new monomer at the desired position. this is because
+  //some features may want to do things with it
+  ing.modifyMolecules().addMonomer(position.getX(),position.getY(),position.getZ());
+  particleIndex=ing.getMolecules().size()-1;
+  //now apply it to the features so that the features can make alterations,
+  //for example set the attribute tag, if the FeatureAttributes is used
+  ing.applyMove(ing,*this);		
+}
+
+#endif //LEMONADE_UPDATER_MOVES_MOVEADDSCMONOMER_H

--- a/include/LeMonADE/updater/moves/MoveAddScMonomer.h
+++ b/include/LeMonADE/updater/moves/MoveAddScMonomer.h
@@ -31,6 +31,9 @@ along with LeMonADE.  If not, see <http://www.gnu.org/licenses/>.
 #include <LeMonADE/updater/moves/MoveBase.h>
 
 /**
+ * @file
+ * 
+ * @author Hauke
  * @class MoveAddScMonomer
  *
  * @brief Standard local bfm-move on simple cubic lattice for the scBFM to add a vertex/monomer
@@ -38,8 +41,8 @@ along with LeMonADE.  If not, see <http://www.gnu.org/licenses/>.
  * @deprecated Untested!!
  *
  * @todo Test!
- *
- * @todo Comment!
+ * 
+ * @todo Code doubling with MoveAddBccMonomer! Specialized class only neccessary to enable the features to handle the moves types differently.
  **/
 class MoveAddScMonomer:public MoveBase
 {
@@ -53,18 +56,30 @@ public:
 
   //! Apply the move to the system given as argument
   template< class IngredientsType> void apply(IngredientsType& ing);
-    
+  
+  //! setter function for type of new monomer
   void setType(int32_t t){type=t;}
+  //! setter function for position of new monomer taking a VectorInt3
   void setPosition(VectorInt3 pos){position=pos;}
+  //! setter function for position of new monomer taking a triple of ints
   void setPosition(int32_t x,int32_t y,int32_t z){position.setX(x);position.setY(y);position.setZ(z);}
+  //! getter function for the type of the new monomer
   int32_t getType() const{return type;}
+  //! getter function for the position of the new monomer returning a VectorInt3
   const VectorInt3 getPosition() const {return position;}
+  //! getter function for index of the new monomer. This is ing.getMolecules().size() before applying and ing.getMolecules().size()-1 after applying the move.
   size_t getParticleIndex() const {return particleIndex;}
   
 private:
+  //! position where the new monomer is placed in the simulation box
   VectorInt3 position;
+  //! type that is applied to the new monomer, requires Feature FeatureAttributes with int-Type
   int32_t type;
-  size_t particleIndex; /*set when apply is called. useful if Features want to alter the particle when applying the move*/
+  /** 
+   * @brief Index of new PartileThis is ing.getMolecules().size() before applying and ing.getMolecules().size()-1 after applying the move.
+   * @details It is set when apply is called. useful if Features want to alter the particle when applying the move
+   */
+  size_t particleIndex;
 };
 
 
@@ -73,7 +88,7 @@ private:
 /////////// implementation of the members ///////////////////////////////////
 
 /*****************************************************************************/
-/*
+/**
  * @brief reset the probability
  */
 template <class IngredientsType>
@@ -84,8 +99,8 @@ void MoveAddScMonomer::init(const IngredientsType& ing)
 }
 
 /*****************************************************************************/
-/*
- * check if the move is allowed by the system given as argument.
+/**
+ * @brief check if the move is allowed by the system given as argument.
  */
 template <class IngredientsType>
 bool MoveAddScMonomer::check(IngredientsType& ing)
@@ -95,8 +110,8 @@ bool MoveAddScMonomer::check(IngredientsType& ing)
 }
   
 /*****************************************************************************/
-/*
- * apply the move to the system given as argument
+/**
+ * @brief apply the move to the system given as argument
  */
 template< class IngredientsType>
 void MoveAddScMonomer::apply(IngredientsType& ing)
@@ -107,7 +122,7 @@ void MoveAddScMonomer::apply(IngredientsType& ing)
   particleIndex=ing.getMolecules().size()-1;
   //now apply it to the features so that the features can make alterations,
   //for example set the attribute tag, if the FeatureAttributes is used
-  ing.applyMove(ing,*this);		
+  ing.applyMove(ing,*this);
 }
 
-#endif
+#endif //LEMONADE_UPDATER_MOVES_MOVEADDSCMONOMER_H

--- a/tests/feature/TestFeatureExcludedVolumeBcc.cpp
+++ b/tests/feature/TestFeatureExcludedVolumeBcc.cpp
@@ -65,6 +65,15 @@ TEST(TestFeatureExcludedVolumeBcc,Moves)
     std::cout<< "first synchronize\n"; 
     ingredients.synchronize(ingredients);
     
+    // **************   check inconsistent moves   *****
+    MoveLocalSc scmove;
+    scmove.init(ingredients);
+    EXPECT_ANY_THROW(scmove.check(ingredients));
+    
+    MoveAddScMonomer addscmove;
+    addscmove.init(ingredients);
+    EXPECT_ANY_THROW(addscmove.check(ingredients));
+    
     // **************   check base move   **************
     basemove.init(ingredients);
     EXPECT_TRUE(basemove.check(ingredients));

--- a/tests/feature/TestFeatureExcludedVolumeBcc.cpp
+++ b/tests/feature/TestFeatureExcludedVolumeBcc.cpp
@@ -1,0 +1,276 @@
+/*--------------------------------------------------------------------------------
+    ooo      L   attice-based  |
+  o\.|./o    e   xtensible     | LeMonADE: An Open Source Implementation of the
+ o\.\|/./o   Mon te-Carlo      |           Bond-Fluctuation-Model for Polymers
+oo---0---oo  A   lgorithm and  |
+ o/./|\.\o   D   evelopment    | Copyright (C) 2013-2015 by 
+  o/.|.\o    E   nvironment    | LeMonADE Principal Developers (see AUTHORS)
+    ooo                        | 
+----------------------------------------------------------------------------------
+
+This file is part of LeMonADE.
+
+LeMonADE is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+LeMonADE is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with LeMonADE.  If not, see <http://www.gnu.org/licenses/>.
+
+--------------------------------------------------------------------------------*/
+//#include <cstdlib>
+#include "gtest/gtest.h"
+
+#include <LeMonADE/core/ConfigureSystem.h>
+#include <LeMonADE/core/Ingredients.h>
+#include <LeMonADE/feature/FeatureBondset.h>
+#include <LeMonADE/feature/FeatureExcludedVolumeBcc.h>
+
+using namespace std;
+
+TEST(TestFeatureExcludedVolumeBcc,Moves)
+{
+ 
+  typedef LOKI_TYPELIST_2(FeatureBondset< >,FeatureExcludedVolumeBcc< >) Features;
+
+  typedef ConfigureSystem<VectorInt3,Features> Config;
+  typedef Ingredients<Config> Ing;
+  Ing ingredients;
+  
+  //prepare ingredients
+    ingredients.setBoxX(32);
+    ingredients.setBoxY(32);
+    ingredients.setBoxZ(32);
+    ingredients.setPeriodicX(1);
+    ingredients.setPeriodicY(1);
+    ingredients.setPeriodicZ(1);
+    
+    //one move of every type
+    MoveBase basemove;
+    MoveLocalBcc bccmove;
+    MoveAddBccMonomer addmove;
+    
+    ingredients.modifyMolecules().resize(4);
+    ingredients.modifyMolecules()[0].setAllCoordinates(1,1,1);
+    ingredients.modifyMolecules()[1].setAllCoordinates(1,5,1);
+    ingredients.modifyMolecules()[2].setAllCoordinates(31,3,1);
+    ingredients.modifyMolecules()[3].setAllCoordinates(1,1,3);
+    
+    std::cout<< "first synchronize\n"; 
+    ingredients.synchronize(ingredients);
+    
+    // **************   check base move   **************
+    basemove.init(ingredients);
+    EXPECT_TRUE(basemove.check(ingredients));
+    //should change nothing
+    basemove.apply(ingredients);
+    EXPECT_EQ(ingredients.getMolecules()[0],VectorInt3(1,1,1));
+    EXPECT_EQ(ingredients.getMolecules()[1],VectorInt3(1,5,1));
+    EXPECT_EQ(ingredients.getMolecules()[2],VectorInt3(31,3,1));
+    EXPECT_EQ(ingredients.getMolecules()[3],VectorInt3(1,1,3));
+    
+    // **************   check bcc move   **************
+    //collossion monomer 2 x+1 to 0 and 1
+    while((bccmove.getDir().getX()!=1) || (bccmove.getIndex()!=2)) bccmove.init(ingredients);
+    EXPECT_FALSE(bccmove.check(ingredients));
+    
+    //collision monomer 0 y+1, x+1 to 2
+    while((bccmove.getDir().getX()!=-1) || (bccmove.getDir().getY()!=1) || (bccmove.getIndex()!=0)) bccmove.init(ingredients);
+    EXPECT_FALSE(bccmove.check(ingredients));
+    
+    //collision monomer 0 z+1 to 3
+    while((bccmove.getDir().getZ()!=1) || (bccmove.getIndex()!=0)) bccmove.init(ingredients);
+    EXPECT_FALSE(bccmove.check(ingredients));
+    
+    //collision monomer 1 x-1, y-1 to 2
+    while((bccmove.getDir().getX()!=-1) || (bccmove.getDir().getY()!=-1) || (bccmove.getIndex()!=1)) bccmove.init(ingredients);
+    EXPECT_FALSE(bccmove.check(ingredients));
+    
+    //collision monomer 3 z-1 to 0
+    while((bccmove.getDir().getZ()!=-1) || (bccmove.getIndex()!=3)) bccmove.init(ingredients);
+    EXPECT_FALSE(bccmove.check(ingredients));
+    
+    /* ################################ */
+    //some possible moves
+    while((bccmove.getDir().getZ()!=-1) || (bccmove.getDir().getX()!=1) || (bccmove.getIndex()!=0)) bccmove.init(ingredients);
+    EXPECT_TRUE(bccmove.check(ingredients));
+    
+    while((bccmove.getDir().getX()!=-1) || (bccmove.getIndex()!=2)) bccmove.init(ingredients);
+    EXPECT_TRUE(bccmove.check(ingredients));
+    
+    while((bccmove.getDir().getZ()!=1) || (bccmove.getIndex()!=3)) bccmove.init(ingredients);
+    EXPECT_TRUE(bccmove.check(ingredients));
+    
+    while((bccmove.getDir().getX()!=1) || (bccmove.getIndex()!=1)) bccmove.init(ingredients);
+    EXPECT_TRUE(bccmove.check(ingredients));
+    
+    //shift monomer and try again
+    ingredients.modifyMolecules()[1].setAllCoordinates(4,2,2);
+    std::cout<< "second synchronize\n"; 
+    ingredients.synchronize(ingredients);
+    
+    //some possible moves
+    while((bccmove.getDir().getX()!=-1) || (bccmove.getIndex()!=1)) bccmove.init(ingredients);
+    EXPECT_TRUE(bccmove.check(ingredients));
+    
+    //some possible moves
+    while((bccmove.getDir().getX()!=1) || (bccmove.getDir().getZ()!=1) || (bccmove.getIndex()!=3)) bccmove.init(ingredients);
+    EXPECT_TRUE(bccmove.check(ingredients));
+    
+    //use a localmove (without synchronize) and try again
+    while((bccmove.getDir().getX()!=-1) || (bccmove.getDir().getY()!=1) || (bccmove.getDir().getZ()!=-1) || (bccmove.getIndex()!=1)) bccmove.init(ingredients);
+    EXPECT_TRUE(bccmove.check(ingredients));
+    bccmove.apply(ingredients);
+    
+    //collision monomer 2 up to 3
+    while((bccmove.getDir().getX()!=1) || (bccmove.getDir().getY()!=1) || (bccmove.getIndex()!=0)) bccmove.init(ingredients);
+    EXPECT_FALSE(bccmove.check(ingredients));
+    
+    //collision monomer 2 down-left-z-down to 1
+    while((bccmove.getDir().getX()!=-1) || (bccmove.getDir().getY()!=-1) ||  (bccmove.getIndex()!=1)) bccmove.init(ingredients);
+    EXPECT_FALSE(bccmove.check(ingredients));
+    
+    // **************   check add move   **************
+    std::cout<< "check addmoves\n";
+    ingredients.modifyMolecules().resize(2);
+    ingredients.modifyMolecules()[0].setAllCoordinates(1,1,1);
+    ingredients.modifyMolecules()[1].setAllCoordinates(5,1,1);
+    std::cout<< "third synchronize\n"; 
+    ingredients.synchronize(ingredients);
+    
+    addmove.init(ingredients);
+    
+    //position itsself occupied
+    addmove.setPosition(1,1,1);
+    EXPECT_FALSE(addmove.check(ingredients));
+    
+    //position itsself occupied
+    addmove.setPosition(5,1,1);
+    EXPECT_FALSE(addmove.check(ingredients));
+    
+    //position on "o" lattice occupied
+    addmove.setPosition(0,0,0);
+    EXPECT_FALSE(addmove.check(ingredients));
+    
+    //position on "o" lattice occupied
+    addmove.setPosition(2,2,2);
+    EXPECT_FALSE(addmove.check(ingredients));
+    
+    //position on "o" lattice occupied
+    addmove.setPosition(4,0,0);
+    EXPECT_FALSE(addmove.check(ingredients));
+    
+    //position on "o" lattice occupied
+    addmove.setPosition(4,2,2);
+    EXPECT_FALSE(addmove.check(ingredients));
+    
+    //position on "o" lattice occupied
+    addmove.setPosition(6,2,2);
+    EXPECT_FALSE(addmove.check(ingredients));
+    
+    //one position is even, the others odd
+    addmove.setPosition(9,8,8);
+    EXPECT_FALSE(addmove.check(ingredients));
+    
+    //one position is even, the others odd
+    addmove.setPosition(8,8,9);
+    EXPECT_FALSE(addmove.check(ingredients));
+    
+    //one position is even, the others odd
+    addmove.setPosition(8,9,8);
+    EXPECT_FALSE(addmove.check(ingredients));
+    
+    //creation of "lines" of monomer
+    addmove.setPosition(3,1,1);
+    EXPECT_FALSE(addmove.check(ingredients));
+    
+    //possible creations
+    addmove.setPosition(3,-1,-1);
+    EXPECT_TRUE(addmove.check(ingredients));  //false?
+    
+    //possible creations
+    addmove.setPosition(3,31,31);
+    EXPECT_TRUE(addmove.check(ingredients));
+    
+    //possible creations
+    addmove.setPosition(7,1,1);
+    EXPECT_TRUE(addmove.check(ingredients));
+    
+    //possible creations
+    addmove.setPosition(-1,1,1);
+    EXPECT_TRUE(addmove.check(ingredients));  //false?
+    
+    //possible creations
+    addmove.setPosition(31,1,1);
+    EXPECT_TRUE(addmove.check(ingredients));
+    
+    //apply move and check position again
+    addmove.apply(ingredients);
+    addmove.init(ingredients);
+    EXPECT_FALSE(addmove.check(ingredients));
+    
+    //create random system and check it by synchronize
+    for(uint32_t i=0;i<800;i++){
+      bool accept_move(false);
+      while(!accept_move){
+        addmove.setPosition(std::rand()%32,std::rand()%32,std::rand()%32);
+	if(addmove.check(ingredients)){
+	  addmove.apply(ingredients);
+	  accept_move=true;
+	}
+      }
+    }
+    EXPECT_NO_THROW(ingredients.synchronize());
+    
+}
+
+TEST(TestFeatureExcludedVolumeBcc,CheckInterface)
+{
+	typedef LOKI_TYPELIST_1(FeatureExcludedVolumeBcc< >) Features;
+
+	typedef ConfigureSystem<VectorInt3,Features> Config;
+	typedef Ingredients<Config> Ing;
+	Ing ingredients;
+
+	 //prepare ingredients1
+	    ingredients.setBoxX(32);
+	    ingredients.setBoxY(32);
+	    ingredients.setBoxZ(32);
+	    ingredients.setPeriodicX(1);
+	    ingredients.setPeriodicY(1);
+	    ingredients.setPeriodicZ(1);
+	    //set up ingredients
+	    typename Ing::molecules_type& molecules=ingredients.modifyMolecules();
+
+	    molecules.resize(3);
+	    molecules[0].setAllCoordinates(9,10,10);
+	    molecules[1].setAllCoordinates(13,10,10);
+
+	    //initially is set to false
+	    //before synchronize: latticeIsNotUpdated
+	    EXPECT_FALSE(ingredients.isLatticeFilledUp());
+
+	    ingredients.synchronize(ingredients);
+
+	    //after synchronize: latticeIsUpdated
+	    EXPECT_TRUE(ingredients.isLatticeFilledUp());
+
+	    //manually setting it to false
+	    ingredients.setLatticeFilledUp(false);
+	    EXPECT_FALSE(ingredients.isLatticeFilledUp());
+
+	    //manually setting it to true
+	    ingredients.setLatticeFilledUp(true);
+	    EXPECT_TRUE(ingredients.isLatticeFilledUp());
+
+	    //before synchronize: latticeIsNotUpdated
+	    ingredients.synchronize(ingredients);
+	    EXPECT_TRUE(ingredients.isLatticeFilledUp());
+
+}

--- a/tests/feature/TestFeatureExcludedVolumeSc.cpp
+++ b/tests/feature/TestFeatureExcludedVolumeSc.cpp
@@ -63,6 +63,16 @@ TEST(TestFeatureExcludedVolumeSc,Moves)
     
     ingredients.synchronize(ingredients);
     
+    // **************   check inconsistent moves   *****
+    MoveLocalBcc bccmove;
+    bccmove.init(ingredients);
+    EXPECT_ANY_THROW(bccmove.check(ingredients));
+    
+    MoveAddBccMonomer addbccmove;
+    addbccmove.init(ingredients);
+    EXPECT_ANY_THROW(addbccmove.check(ingredients));
+    
+    
     // **************   check base move   **************
     basemove.init(ingredients);
     EXPECT_TRUE(basemove.check(ingredients));

--- a/tests/feature/TestFeatureExcludedVolumeSc.cpp
+++ b/tests/feature/TestFeatureExcludedVolumeSc.cpp
@@ -192,6 +192,20 @@ TEST(TestFeatureExcludedVolumeSc,Moves)
     addmove.init(ingredients);
     EXPECT_FALSE(addmove.check(ingredients));
     
+    //create random system and check it by synchronize
+    std::cout << "create random config by addmove and check by snychronize"<<std::endl;
+    for(uint32_t i=0;i<2000;i++){
+      bool accept_move(false);
+      while(!accept_move){
+        addmove.setPosition(std::rand()%32,std::rand()%32,std::rand()%32);
+	if(addmove.check(ingredients)){
+	  addmove.apply(ingredients);
+	  accept_move=true;
+	}
+      }
+    }
+    EXPECT_NO_THROW(ingredients.synchronize());
+   
 }
     
 TEST(TestFeatureExcludedVolumeSc,CheckInterface)

--- a/tests/feature/TestFeatureExcludedVolumeSc.cpp
+++ b/tests/feature/TestFeatureExcludedVolumeSc.cpp
@@ -1,0 +1,268 @@
+/*--------------------------------------------------------------------------------
+    ooo      L   attice-based  |
+  o\.|./o    e   xtensible     | LeMonADE: An Open Source Implementation of the
+ o\.\|/./o   Mon te-Carlo      |           Bond-Fluctuation-Model for Polymers
+oo---0---oo  A   lgorithm and  |
+ o/./|\.\o   D   evelopment    | Copyright (C) 2013-2015 by 
+  o/.|.\o    E   nvironment    | LeMonADE Principal Developers (see AUTHORS)
+    ooo                        | 
+----------------------------------------------------------------------------------
+
+This file is part of LeMonADE.
+
+LeMonADE is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+LeMonADE is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with LeMonADE.  If not, see <http://www.gnu.org/licenses/>.
+
+--------------------------------------------------------------------------------*/
+
+#include "gtest/gtest.h"
+
+#include <LeMonADE/LeMonADE.h>
+#include <LeMonADE/feature/FeatureExcludedVolumeSc.h>
+
+using namespace std;
+
+TEST(TestFeatureExcludedVolumeSc,CheckMoves)
+{
+ 
+  typedef LOKI_TYPELIST_2(FeatureBondset< >,FeatureExcludedVolumeSc< >) Features;
+
+  typedef ConfigureSystem<VectorInt3,Features> Config;
+  typedef Ingredients<Config> Ing;
+  Ing ingredients;
+  
+  //prepare ingredients
+    ingredients.setBoxX(32);
+    ingredients.setBoxY(32);
+    ingredients.setBoxZ(32);
+    ingredients.setPeriodicX(1);
+    ingredients.setPeriodicY(1);
+    ingredients.setPeriodicZ(1);
+    
+    //one move of every type
+    MoveBase basemove;
+    MoveLocalSc scmove;
+    MoveAddScMonomer addmove;
+    
+    ingredients.modifyMolecules().resize(3);
+    ingredients.modifyMolecules()[0].setAllCoordinates(0,0,0);
+    ingredients.modifyMolecules()[1].setAllCoordinates(2,0,0);
+    ingredients.modifyMolecules()[2].setAllCoordinates(1,0,30);
+    
+    ingredients.synchronize(ingredients);
+    
+    // **************   check base move   **************
+    basemove.init(ingredients);
+    EXPECT_TRUE(basemove.check(ingredients));
+    //should change nothing
+    basemove.apply(ingredients);
+    EXPECT_EQ(ingredients.getMolecules()[0],VectorInt3(0,0,0));
+    EXPECT_EQ(ingredients.getMolecules()[1],VectorInt3(2,0,0));
+    EXPECT_EQ(ingredients.getMolecules()[2],VectorInt3(1,0,30));
+    
+    // **************   check sc move   **************
+    //collossion to the right
+    while((scmove.getDir().getX()!=1) || (scmove.getIndex()!=0)) scmove.init(ingredients);
+    EXPECT_FALSE(scmove.check(ingredients));
+    
+    //collision 0 downwards via periodic boundaries
+    while((scmove.getDir().getZ()!=-1) || (scmove.getIndex()!=0)) scmove.init(ingredients);
+    EXPECT_FALSE(scmove.check(ingredients));
+    
+    //collision to the left
+    while((scmove.getDir().getX()!=-1) || (scmove.getIndex()!=1)) scmove.init(ingredients);
+    EXPECT_FALSE(scmove.check(ingredients));
+    
+    //collision 1 downwards via periodic boundaries
+    while((scmove.getDir().getZ()!=-1) || (scmove.getIndex()!=1)) scmove.init(ingredients);
+    EXPECT_FALSE(scmove.check(ingredients));
+    
+    //collision upwards via periodic boundaries
+    while((scmove.getDir().getZ()!=1) || (scmove.getIndex()!=2)) scmove.init(ingredients);
+    EXPECT_FALSE(scmove.check(ingredients));
+    
+    //some possible moves
+    while((scmove.getDir().getX()!=1) || (scmove.getIndex()!=2)) scmove.init(ingredients);
+    EXPECT_TRUE(scmove.check(ingredients));
+    while((scmove.getDir().getX()!=-1) || (scmove.getIndex()!=2)) scmove.init(ingredients);
+    EXPECT_TRUE(scmove.check(ingredients));
+    while((scmove.getDir().getX()!=-1) || (scmove.getIndex()!=0)) scmove.init(ingredients);
+    EXPECT_TRUE(scmove.check(ingredients));
+    while((scmove.getDir().getY()!=1) || (scmove.getIndex()!=1)) scmove.init(ingredients);
+    EXPECT_TRUE(scmove.check(ingredients));
+    while((scmove.getDir().getY()!=-1) || (scmove.getIndex()!=1)) scmove.init(ingredients);
+    EXPECT_TRUE(scmove.check(ingredients));
+    
+    //shift monomer and try again
+    ingredients.modifyMolecules()[1].setAllCoordinates(2,1,0);
+    ingredients.synchronize(ingredients);
+    
+    //collossion to the right
+    while((scmove.getDir().getX()!=1) || (scmove.getIndex()!=0)) scmove.init(ingredients);
+    EXPECT_FALSE(scmove.check(ingredients));
+    
+    //collision 0 downwards via periodic boundaries
+    while((scmove.getDir().getZ()!=-1) || (scmove.getIndex()!=0)) scmove.init(ingredients);
+    EXPECT_FALSE(scmove.check(ingredients));
+    
+    //collision to the left
+    while((scmove.getDir().getX()!=-1) || (scmove.getIndex()!=1)) scmove.init(ingredients);
+    EXPECT_FALSE(scmove.check(ingredients));
+    
+    //collision 1 downwards via periodic boundaries
+    while((scmove.getDir().getZ()!=-1) || (scmove.getIndex()!=1)) scmove.init(ingredients);
+    EXPECT_FALSE(scmove.check(ingredients));
+    
+    //collision upwards via periodic boundaries
+    while((scmove.getDir().getZ()!=1) || (scmove.getIndex()!=2)) scmove.init(ingredients);
+    EXPECT_FALSE(scmove.check(ingredients));
+    
+    //use a localmove (without synchronize) and try again
+    while((scmove.getDir().getY()!=1) || (scmove.getIndex()!=0)) scmove.init(ingredients);
+    EXPECT_TRUE(scmove.check(ingredients));
+    scmove.apply(ingredients);
+    
+    //collossion to the right
+    while((scmove.getDir().getX()!=1) || (scmove.getIndex()!=0)) scmove.init(ingredients);
+    EXPECT_FALSE(scmove.check(ingredients));
+    
+    //collision 0 downwards via periodic boundaries
+    while((scmove.getDir().getZ()!=-1) || (scmove.getIndex()!=0)) scmove.init(ingredients);
+    EXPECT_FALSE(scmove.check(ingredients));
+    
+    //collision to the left
+    while((scmove.getDir().getX()!=-1) || (scmove.getIndex()!=1)) scmove.init(ingredients);
+    EXPECT_FALSE(scmove.check(ingredients));
+    
+    //collision upwards via periodic boundaries
+    while((scmove.getDir().getZ()!=1) || (scmove.getIndex()!=2)) scmove.init(ingredients);
+    EXPECT_FALSE(scmove.check(ingredients));
+    
+    // **************   check add move   **************
+    
+    addmove.init(ingredients);
+    
+    addmove.setPosition(0,0,0);
+    EXPECT_FALSE(addmove.check(ingredients));
+    
+    addmove.setPosition(1,0,0);
+    EXPECT_FALSE(addmove.check(ingredients));
+    
+    addmove.setPosition(2,0,0);
+    EXPECT_FALSE(addmove.check(ingredients));
+    
+    addmove.setPosition(3,0,0);
+    EXPECT_FALSE(addmove.check(ingredients));
+    
+    addmove.setPosition(4,0,0);
+    EXPECT_TRUE(addmove.check(ingredients));
+    
+    addmove.setPosition(0,0,1);
+    EXPECT_FALSE(addmove.check(ingredients));
+    
+    addmove.setPosition(0,0,2);
+    EXPECT_TRUE(addmove.check(ingredients));
+    
+    addmove.setPosition(1,0,-1);
+    EXPECT_FALSE(addmove.check(ingredients));
+    
+    addmove.setPosition(1,-1,-1);
+    EXPECT_FALSE(addmove.check(ingredients));
+    
+    addmove.setPosition(1,31,31);
+    EXPECT_FALSE(addmove.check(ingredients));
+    
+    addmove.setPosition(1,-1,0);
+    EXPECT_TRUE(addmove.check(ingredients));
+    
+    //apply move and check position again
+    addmove.apply(ingredients);
+    addmove.init(ingredients);
+    EXPECT_FALSE(addmove.check(ingredients));
+    
+}
+
+TEST(TestFeatureExcludedVolumeSc,ApplyMoves)
+{
+ 
+  typedef LOKI_TYPELIST_2(FeatureBondset< >,FeatureExcludedVolumeSc< >) Features;
+
+  typedef ConfigureSystem<VectorInt3,Features> Config;
+  typedef Ingredients<Config> Ing;
+  Ing ingredients;
+  
+  //prepare ingredients
+  ingredients.setBoxX(32);
+  ingredients.setBoxY(32);
+  ingredients.setBoxZ(32);
+  ingredients.setPeriodicX(1);
+  ingredients.setPeriodicY(1);
+  ingredients.setPeriodicZ(1);
+  
+  ingredients.modifyMolecules().resize(1);
+  ingredients.modifyMolecules()[0].setAllCoordinates(0,0,0);
+  
+  ingredients.synchronize(ingredients);
+  
+  MoveBase basemove;
+  basemove.init(ingredients);
+  basemove.apply(ingredients);
+  EXPECT_EQ(ingredients.getMolecules()[0],VectorInt3(0,0,0));
+    
+}
+    
+    
+TEST(TestFeatureExcludedVolumeSc,CheckInterface)
+{
+	typedef LOKI_TYPELIST_1(FeatureExcludedVolumeSc< >) Features;
+
+	typedef ConfigureSystem<VectorInt3,Features> Config;
+	typedef Ingredients<Config> Ing;
+	Ing ingredients;
+
+	 //prepare ingredients1
+	    ingredients.setBoxX(32);
+	    ingredients.setBoxY(32);
+	    ingredients.setBoxZ(32);
+	    ingredients.setPeriodicX(1);
+	    ingredients.setPeriodicY(1);
+	    ingredients.setPeriodicZ(1);
+	    //set up ingredients
+	    typename Ing::molecules_type& molecules=ingredients.modifyMolecules();
+
+	    molecules.resize(3);
+	    molecules[0].setAllCoordinates(9,10,10);
+	    molecules[1].setAllCoordinates(13,10,10);
+
+	    //initially is set to false
+	    //before synchronize: latticeIsNotUpdated
+	    EXPECT_FALSE(ingredients.isLatticeFilledUp());
+
+	    ingredients.synchronize(ingredients);
+
+	    //after synchronize: latticeIsUpdated
+	    EXPECT_TRUE(ingredients.isLatticeFilledUp());
+
+	    //manually setting it to false
+	    ingredients.setLatticeFilledUp(false);
+	    EXPECT_FALSE(ingredients.isLatticeFilledUp());
+
+	    //manually setting it to true
+	    ingredients.setLatticeFilledUp(true);
+	    EXPECT_TRUE(ingredients.isLatticeFilledUp());
+
+	    //before synchronize: latticeIsNotUpdated
+	    ingredients.synchronize(ingredients);
+	    EXPECT_TRUE(ingredients.isLatticeFilledUp());
+
+}

--- a/tests/feature/TestFeatureExcludedVolumeSc.cpp
+++ b/tests/feature/TestFeatureExcludedVolumeSc.cpp
@@ -27,12 +27,14 @@ along with LeMonADE.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "gtest/gtest.h"
 
-#include <LeMonADE/LeMonADE.h>
+#include <LeMonADE/core/ConfigureSystem.h>
+#include <LeMonADE/core/Ingredients.h>
+#include <LeMonADE/feature/FeatureBondset.h>
 #include <LeMonADE/feature/FeatureExcludedVolumeSc.h>
 
 using namespace std;
 
-TEST(TestFeatureExcludedVolumeSc,CheckMoves)
+TEST(TestFeatureExcludedVolumeSc,Moves)
 {
  
   typedef LOKI_TYPELIST_2(FeatureBondset< >,FeatureExcludedVolumeSc< >) Features;
@@ -191,36 +193,6 @@ TEST(TestFeatureExcludedVolumeSc,CheckMoves)
     EXPECT_FALSE(addmove.check(ingredients));
     
 }
-
-TEST(TestFeatureExcludedVolumeSc,ApplyMoves)
-{
- 
-  typedef LOKI_TYPELIST_2(FeatureBondset< >,FeatureExcludedVolumeSc< >) Features;
-
-  typedef ConfigureSystem<VectorInt3,Features> Config;
-  typedef Ingredients<Config> Ing;
-  Ing ingredients;
-  
-  //prepare ingredients
-  ingredients.setBoxX(32);
-  ingredients.setBoxY(32);
-  ingredients.setBoxZ(32);
-  ingredients.setPeriodicX(1);
-  ingredients.setPeriodicY(1);
-  ingredients.setPeriodicZ(1);
-  
-  ingredients.modifyMolecules().resize(1);
-  ingredients.modifyMolecules()[0].setAllCoordinates(0,0,0);
-  
-  ingredients.synchronize(ingredients);
-  
-  MoveBase basemove;
-  basemove.init(ingredients);
-  basemove.apply(ingredients);
-  EXPECT_EQ(ingredients.getMolecules()[0],VectorInt3(0,0,0));
-    
-}
-    
     
 TEST(TestFeatureExcludedVolumeSc,CheckInterface)
 {


### PR DESCRIPTION
Adding two different features for bcc and sc bfm. Now there is some code doubling, but we have high performance Excluded Volume Checks for both Sc and Bcc BFM. 
Adding MoveAddBccMonomer. Again some code doubling with the Sc counterpart,  MoveAddScMonomer, but now systems for bcc and sc bfm can be created using the add monomer moves beeing safer than adding monomers "by hand".
Test provides for the Features, using all kinds of moves.
