### PR TITLE
MonomerGroup: changed interface of constructor to avoid a pointer.

### DIFF
--- a/include/LeMonADE/analyzer/AnalyzerRadiusOfGyration.h
+++ b/include/LeMonADE/analyzer/AnalyzerRadiusOfGyration.h
@@ -143,7 +143,7 @@ AnalyzerRadiusOfGyration<IngredientsType>::AnalyzerRadiusOfGyration(const Ingred
 ,lowerLimit(lowerMcsLimit)
 ,outputFilePrefix(filenamePrefix)
 {
-	groups.push_back(MonomerGroup<molecules_type>(&(ing.getMolecules())));
+	groups.push_back(MonomerGroup<molecules_type>((ing.getMolecules())));
 	
 	//add all monomers to the group
 	for(size_t n=0; n<ing.getMolecules().size();++n)

--- a/tests/utility/TestGroupByProperty.cpp
+++ b/tests/utility/TestGroupByProperty.cpp
@@ -102,7 +102,7 @@ TEST(GroupByPropertyTest,CreateGroups)
   //to demonstrate that this works just as well. 
   
   std::vector<MonomerGroup < Molecules <VectorInt3> > > zCoordinateGroups;
-  group_by_property(molecules,zCoordinateGroups,MonomerGroup<Molecules<VectorInt3> >(&molecules),ZCoordinate());
+  group_by_property(molecules,zCoordinateGroups,MonomerGroup<Molecules<VectorInt3> >(molecules),ZCoordinate());
   
   //now check if the monomers are correctly sorted into groups
   //start with the connectivityGroups

--- a/tests/utility/TestMonomerGroups.cpp
+++ b/tests/utility/TestMonomerGroups.cpp
@@ -85,7 +85,7 @@ TEST(MonomerGroups, DifferentGroupTypes)
   GroupList connectedObjectsList;
   GroupList linearStrandsList;
   // fills list of groups with connected objects, which belong to a linear strand (including ends)
-  fill_connected_groups( ingredients.getMolecules(), linearStrandsList,    Group(), belongsToLinearStrand() ); 
+  fill_connected_groups( ingredients.getMolecules(), linearStrandsList, Group(), belongsToLinearStrand() ); 
   
   // vector-based groups:
   typedef vector < MonomerGroup<MyIngredients::molecules_type> > MonomerGroupVector;
@@ -93,7 +93,7 @@ TEST(MonomerGroups, DifferentGroupTypes)
 
   fill_connected_groups( ingredients.getMolecules(), 
 			linearStrandsVector,  
-			MonomerGroup<MyIngredients::molecules_type>(&ingredients.getMolecules()), 
+			MonomerGroup<MyIngredients::molecules_type>(ingredients.getMolecules()), 
 			belongsToLinearStrand() );
 
   //now check that the two groups are the same (subgroups have same size)
@@ -133,7 +133,7 @@ TEST(MonomerGroups, CopyGroup)
 	myIngredients.modifyMolecules().connect(0,2,100);
 	
 	//now open a group
-	MonomerGroup<Ing::molecules_type> myGroup(&(myIngredients.getMolecules()));
+	MonomerGroup<Ing::molecules_type> myGroup((myIngredients.getMolecules()));
 	//and put some of the monomers into the group
 	myGroup.push_back(0);
 	myGroup.push_back(1);
@@ -196,7 +196,7 @@ TEST(MonomerGroups, ClearGroup)
 	myIngredients.modifyMolecules().connect(0,2,100);
 	
 	//now open a group
-	MonomerGroup<Ing::molecules_type> myGroup(&(myIngredients.getMolecules()));
+	MonomerGroup<Ing::molecules_type> myGroup((myIngredients.getMolecules()));
 	//and put some of the monomers into the group
 	myGroup.push_back(0);
 	myGroup.push_back(1);
@@ -252,7 +252,7 @@ TEST(MonomerGroups, Erase)
 	myIngredients.modifyMolecules().connect(0,2,100);
 	
 	//now open a group
-	MonomerGroup<Ing::molecules_type> myGroup(&(myIngredients.getMolecules()));
+	MonomerGroup<Ing::molecules_type> myGroup((myIngredients.getMolecules()));
 	//and put some of the monomers into the group
 	myGroup.push_back(0);
 	myGroup.push_back(1);
@@ -312,7 +312,7 @@ TEST(MonomerGroups, RemoveFromGroup)
 	myIngredients.modifyMolecules().connect(0,2,100);
 	
 	//now open a group
-	MonomerGroup<Ing::molecules_type> myGroup(&(myIngredients.getMolecules()));
+	MonomerGroup<Ing::molecules_type> myGroup((myIngredients.getMolecules()));
 	//and put some of the monomers into the group
 	myGroup.push_back(0);
 	myGroup.push_back(1);


### PR DESCRIPTION
The previous interface of the constructor of **_MonomerGroups_** used a **pointer** to a MoleculesType object, because it holds a pointer as a private object. This was considered to be inconsistent and changed to a **reference** in the constructor call. The public member is still a pointer to enable the assignment of an instance of this class. I also changed some names to enhance the readability of the code.

Now a reference is used being consistent with almost all the other constructor calls. Changes effected _TestGroupByProperty,_ _TestMonomerGroups_ and _AnalyzerRadiusOfGyration._ Tests passed correctly on my operation system.
