### PR TITLE
RandomNumberGenerators::seedAll from array or file

### DIFF
--- a/include/LeMonADE/utility/R250.h
+++ b/include/LeMonADE/utility/R250.h
@@ -87,7 +87,7 @@ public:
 	//! initializes the generator with a predefined state, such that numbers can be reproduced.
 	void loadDefaultState();
 	//! initializes the internal state array with 256 values from argument stateArray.
-	void setState(uint32_t* stateArray);
+	void setState( uint32_t const * stateArray );
 
 private:
 	//! applies the random number algorithm to the internal state array (next 256 numbers are generated)

--- a/include/LeMonADE/utility/RandomNumberGenerators.h
+++ b/include/LeMonADE/utility/RandomNumberGenerators.h
@@ -101,7 +101,7 @@ class RandomNumberGenerators
 		//! randomly seed only R250Engine from /dev/urandom
 		void seedR250();
 		//! seed R250Engine with array given as argument
-		void seedR250(uint32_t* seedArray);
+		void seedR250( uint32_t const * seedArray );
 
 		//! randomly seed std:rand()
 		void seedSTDRAND();

--- a/include/LeMonADE/utility/RandomNumberGenerators.h
+++ b/include/LeMonADE/utility/RandomNumberGenerators.h
@@ -35,15 +35,7 @@ along with LeMonADE.  If not, see <http://www.gnu.org/licenses/>.
 //#define RANDOMNUMBERGENERATOR_ENABLE_CPP11
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifdef RANDOMNUMBERGENERATOR_ENABLE_CPP11
-#include <random>
-#endif /*RANDOMNUMBERGENERATOR_ENABLE_CPP11*/
-
-#include <stdexcept>
-#include <iostream>
-#include <fstream>
-#include <sstream>
-#include <cstdlib>
+#include <vector>
 
 #include <LeMonADE/utility/R250.h>
 
@@ -94,6 +86,10 @@ class RandomNumberGenerators
 		////////////////////////////////////////////////////////////////
 		//functions for seeding the random number generators
 
+        //! methods which take 256+1+1 32 bit seeds to be used as seeds
+        void seedAll( uint32_t const * pSeeds );
+        void seedAll( std::vector< uint32_t > const & vSeeds );
+        void seedAll( std::string const & fname );
 		//! randomly initializes all provided RNGs
 		void seedAll();
 		//R250Engine seeding
@@ -105,6 +101,7 @@ class RandomNumberGenerators
 
 		//! randomly seed std:rand()
 		void seedSTDRAND();
+		void seedSTDRAND( uint32_t seed );
 #ifdef RANDOMNUMBERGENERATOR_ENABLE_CPP11
 		//! randomly seed only Mersenne Twister from /dev/urandom
 		void seedMT();

--- a/src/LeMonADE/utility/R250.cpp
+++ b/src/LeMonADE/utility/R250.cpp
@@ -109,12 +109,18 @@ void R250::setState( uint32_t const * stateArray )
 		refresh();
 }
 
-//this resets the state array to a predefined value, so that a defined state
-//can always be obtained if needed. the numbers were generated from /dev/urandom
-//once and then simply copied here.
+/**
+ * this resets the state array to a predefined value, so that a defined state
+ * can always be obtained if needed. the numbers were generated from /dev/urandom
+ * once and then simply copied here.
+ * The array can e.g. be generated with:
+ *   head -c 1024 /dev/urandom | hexdump -v -e '4 4 "0x%08X, " "\n"'; echo
+ */
 void R250::loadDefaultState()
 {
-	uint32_t tmp[R250_RANDOM_PREFETCH] ={128861083 ,1578465172 ,1132109222 ,1536640935 ,488265105 ,249545814 ,
+	static uint32_t const tmp[R250_RANDOM_PREFETCH] =
+    {
+        128861083 ,1578465172 ,1132109222 ,1536640935 ,488265105 ,249545814 ,
 		931473061 ,816964859 ,296369473 ,818986032 ,530371272 ,295126204 ,
 		1516346231 ,3026009 ,245630516 ,671061864 ,791099058 ,852977361 ,
 		635292087 ,1059222032 ,288528100 ,877554999 ,1941668641 ,407091003 ,
@@ -156,7 +162,8 @@ void R250::loadDefaultState()
 		866089755 ,313184427 ,619508128 ,759157274 ,627786029 ,640921970 ,
 		5035326 ,351442498 ,310023587 ,713733322 ,1567488348 ,225865858 ,
 		1379860041 ,1091951759 ,952392682 ,650949040 ,2000007399 ,82102099 ,
-		1654883130 ,394023729 ,2069457331 ,1270363068};
+		1654883130 ,394023729 ,2069457331 ,1270363068
+    };
 
 	for (size_t i=0;i<R250_RANDOM_PREFETCH;i++)
 	{

--- a/src/LeMonADE/utility/R250.cpp
+++ b/src/LeMonADE/utility/R250.cpp
@@ -96,7 +96,7 @@ void R250::loadRandomState()
 }
 
 //this allows to set the internal state array to given values.
-void R250::setState(uint32_t* stateArray)
+void R250::setState( uint32_t const * stateArray )
 {
 		for(size_t i=0;i<R250_RANDOM_PREFETCH;i++)
 		{

--- a/src/LeMonADE/utility/RandomNumberGenerators.cpp
+++ b/src/LeMonADE/utility/RandomNumberGenerators.cpp
@@ -25,7 +25,19 @@ along with LeMonADE.  If not, see <http://www.gnu.org/licenses/>.
 
 --------------------------------------------------------------------------------*/
 
+#include <cassert>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#ifdef RANDOMNUMBERGENERATOR_ENABLE_CPP11
+#   include <random>
+#endif /*RANDOMNUMBERGENERATOR_ENABLE_CPP11*/
+#include <sstream>
+#include <stdexcept>
+#include <vector>
+
 #include <LeMonADE/utility/RandomNumberGenerators.h>
+
 
 R250* RandomNumberGenerators::r250Engine=0;
 
@@ -64,6 +76,90 @@ RandomNumberGenerators::RandomNumberGenerators()
 RandomNumberGenerators::~RandomNumberGenerators()
 {
 
+}
+
+/**
+ * Uses seeds from a given array. Currently needs 256+1 or 256+1+1 seeds.
+ * Very unsafe. Better to use the std::vector function which checks for enough
+ * input!
+ */
+void RandomNumberGenerators::seedAll( uint32_t const * pSeeds )
+{
+    uint32_t const * curPos = pSeeds;
+
+	//seed the standard rand
+	seedSTDRAND( *( curPos++ ) );
+	//randomly initialize all provided RNGs
+	seedR250( curPos );
+    curPos += R250_RANDOM_PREFETCH;
+
+#ifdef RANDOMNUMBERGENERATOR_ENABLE_CPP11
+	seedMT( *( curPos++ ) );
+#endif /*RANDOMNUMBERGENERATOR_ENABLE_CPP11*/
+}
+
+/**
+ * Uses seeds from a given array. Currently needs 256+1 or 256+1+1 seeds.
+ * Very unsafe. Better to use the std::vector function which checks for enough
+ * input!
+ */
+void RandomNumberGenerators::seedAll( std::vector< uint32_t > const & vSeeds )
+{
+    uint32_t const * curPos = &vSeeds[0];
+    size_t nSeedsRemaining = vSeeds.size();
+
+	//seed the standard rand
+    if ( ! ( nSeedsRemaining >= 1 ) )
+        throw std::invalid_argument( "[seedAll] Not enough seeds given" );
+    --nSeedsRemaining;
+	seedSTDRAND( *( curPos++ ) );
+
+
+	//randomly initialize all provided RNGs
+    if ( ! ( nSeedsRemaining >= R250_RANDOM_PREFETCH ) )
+        throw std::invalid_argument( "[seedAll] Not enough seeds given" );
+	seedR250( curPos );
+    nSeedsRemaining -= R250_RANDOM_PREFETCH;
+    curPos          += R250_RANDOM_PREFETCH;
+
+#ifdef RANDOMNUMBERGENERATOR_ENABLE_CPP11
+    if ( ! ( nSeedsRemaining >= 1 ) )
+        throw std::invalid_argument( "[seedAll] Not enough seeds given" );
+    --nSeedsRemaining;
+	seedMT( *( curPos++ ) );
+#endif /*RANDOMNUMBERGENERATOR_ENABLE_CPP11*/
+}
+
+/**
+ * Reads random seeds from an input file. The file is supposed to contain raw
+ * random data, e.g. created with:
+ *  head -c $(( (256+2)*4 )) /dev/urandom > seeds.dat
+ */
+void RandomNumberGenerators::seedAll( std::string const & fname )
+{
+    std::ifstream fileSeeds( fname.c_str() );
+    if ( fileSeeds.fail() )
+    {
+        std::stringstream msg;
+        msg << "[seedAll] Couldn't open seed file '" << fname << "'";
+        throw std::invalid_argument( msg.str() );
+    }
+    /* seek to end to get file size in bytes */
+    fileSeeds.seekg( 0, std::ios_base::end );
+    size_t const nBytes = fileSeeds.tellg();
+    fileSeeds.seekg( 0 );   // set to beginning again
+    if ( fileSeeds.fail() )
+    {
+        std::stringstream msg;
+        msg << "[seedAll] An error occured when trying to get file size for seed file '" << fname << "'";
+        throw std::invalid_argument( msg.str() );
+    }
+    size_t const nLongs = nBytes / sizeof( uint32_t );
+    std::cerr << "[seedAll] Seed file contains " << nLongs << " uint32_t data\n";
+
+    std::vector< uint32_t > vSeeds( nLongs );
+    fileSeeds.read( (char *) &vSeeds[0], nLongs * sizeof( uint32_t ) );
+    seedAll( vSeeds );
 }
 
 void RandomNumberGenerators::seedAll()
@@ -114,6 +210,11 @@ void RandomNumberGenerators::seedSTDRAND()
 
 	}
 
+}
+
+void RandomNumberGenerators::seedSTDRAND( uint32_t const seed )
+{
+    std::srand( seed );
 }
 
 

--- a/src/LeMonADE/utility/RandomNumberGenerators.cpp
+++ b/src/LeMonADE/utility/RandomNumberGenerators.cpp
@@ -88,7 +88,7 @@ void RandomNumberGenerators::seedR250()
 
 //seed R250Engine with array of 256 values
 //state array has to contain 256 ideally random values
-void RandomNumberGenerators::seedR250(uint32_t* stateArray)
+void RandomNumberGenerators::seedR250( uint32_t const * stateArray )
 {
 	r250Engine->setState(stateArray);
 }
@@ -142,7 +142,7 @@ void RandomNumberGenerators::seedMT()
 }
 
 //seed Mersenne Twister
-void RandomNumberGenerators::seedMT(uint32_t seed)
+void RandomNumberGenerators::seedMT( uint32_t seed )
 {
 	mt19937Engine->seed(seed);
 }


### PR DESCRIPTION
A proposition for how to use seedAll with a file of seeds, e.g. created with `head -c 1032 > seeds.dat`.
seedAll now also takes a file name or an std::vector or a simple pointer to an array, with the latter being the most unsafe variant which I only added for legacy.
Also moves some includes from the header into the cpp. In general only includes which are needed directly in the header file should be there.