### PR TITLE
cleanup of DepthIteratorPredicated

### DIFF
--- a/include/LeMonADE/utility/DepthIteratorPredicates.h
+++ b/include/LeMonADE/utility/DepthIteratorPredicates.h
@@ -41,10 +41,6 @@ along with LeMonADE.  If not, see <http://www.gnu.org/licenses/>.
  * @brief Functor providing the information if Vertex is no cross-linking point
  *  (functionality 0 < f <= 2)
  *
- * @deprecated
- *
- * @todo we should reconsider this approach for usability
- *
  * @todo Rename FunctorBelongToLinearStrand
  **/
 struct belongsToLinearStrand {
@@ -59,10 +55,6 @@ struct belongsToLinearStrand {
  * @struct alwaysTrue
  *
  * @brief Functor returning always \a True.
- *
- * @deprecated
- *
- * @todo we should reconsider this approach for usability
  *
  * @todo Rename FunctorAlwaysTrue
  **/
@@ -80,10 +72,6 @@ struct alwaysTrue
  *
  * @brief Functor returning \a True if monomer has at least one bond.
  *
- * @deprecated
- *
- * @todo we should reconsider this approach for usability
- *
  * @todo Rename FunctorAlwaysTrue
  **/
 struct hasBonds
@@ -99,10 +87,6 @@ struct hasBonds
  * @class hasThisType
  *
  * @brief Functor providing the information the Vertex has an attribute tag.
- *
- * @deprecated
- *
- * @todo we should reconsider this approach for usability
  *
  * @todo Rename FunctorHasThisType
  **/
@@ -122,10 +106,6 @@ public:
  * @class hasOneOfTheseTwoTypes
  *
  * @brief Functor providing the information the Vertex has an attribute tag.
- *
- * @deprecated
- *
- * @todo we should reconsider this approach for usability
  *
  * @todo Rename FunctorHasOneOfTheseTypes
  **/
@@ -147,10 +127,6 @@ public:
  *
  * @brief Functor providing the information the Vertex does not have an attribute tag.
  *
- * @deprecated
- *
- * @todo we should reconsider this approach for usability
- *
  * @todo Rename FunctorNotOfType
  **/
 template<int AttributeType>
@@ -170,10 +146,6 @@ public:
  * @class notOfBothTypes
  *
  * @brief Functor providing the information the Vertex does not have an attribute tag.
- *
- * @deprecated
- *
- * @todo we should reconsider this approach for usability
  *
  * @todo Rename FunctorNotOfType
  **/

--- a/include/LeMonADE/utility/DepthIteratorPredicates.h
+++ b/include/LeMonADE/utility/DepthIteratorPredicates.h
@@ -28,8 +28,6 @@ along with LeMonADE.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef LEMONADE_UTILITY_DEPTHITERATORPREDICATES_H
 #define LEMONADE_UTILITY_DEPTHITERATORPREDICATES_H
 
-#include <set>
-
 #include <LeMonADE/utility/Vector3D.h>
 /**
  * @file
@@ -98,7 +96,7 @@ struct hasBonds
 };
 
 /**
- * @class hasType
+ * @class hasThisType
  *
  * @brief Functor providing the information the Vertex has an attribute tag.
  *
@@ -106,23 +104,43 @@ struct hasBonds
  *
  * @todo we should reconsider this approach for usability
  *
- * @todo Rename FunctorHasType
+ * @todo Rename FunctorHasThisType
  **/
+template<int AttributeType>
 class hasType
 {
 public:
-	hasType(int type){types.insert(type);}
-	hasType(int type1,int type2){types.insert(type1); types.insert(type2);}
-	hasType(std::vector<int> typeVector){for(size_t n=0;n<typeVector.size();n++) types.insert(typeVector[n]);}
-
+  
 	template<class MoleculesType>
 	bool operator()(const MoleculesType& m, int i)
 	{
-		return types.count(m[i].getAttributeTag());
+		return (m[i].getAttributeTag()==AttributeType?true:false);
 	}
-private:
-	std::set<int> types;
 };
+
+/**
+ * @class hasOneOfTheseTypes
+ *
+ * @brief Functor providing the information the Vertex has an attribute tag.
+ *
+ * @deprecated
+ *
+ * @todo we should reconsider this approach for usability
+ *
+ * @todo Rename FunctorHasOneOfTheseTypes
+ **/
+template<int AttributeType1,int AttributeType2>
+class hasType
+{
+public:
+  
+	template<class MoleculesType>
+	bool operator()(const MoleculesType& m, int i)
+	{
+		return ((m[i].getAttributeTag()==AttributeType1  || m[i].getAttributeTag()==AttributeType2)?true:false);
+	}
+};
+
 
 /**
  * @class notOfType
@@ -144,6 +162,30 @@ public:
 	bool operator()(const MoleculesType& m, int i)
 	{
 		return (m[i].getAttributeTag()==AttributeType?false:true);
+	}
+
+};
+
+/**
+ * @class notOfBothTypes
+ *
+ * @brief Functor providing the information the Vertex does not have an attribute tag.
+ *
+ * @deprecated
+ *
+ * @todo we should reconsider this approach for usability
+ *
+ * @todo Rename FunctorNotOfType
+ **/
+template<int AttributeType1, int AttributeType2>
+class notOfBothTypes
+{
+public:
+
+	template<class MoleculesType>
+	bool operator()(const MoleculesType& m, int i)
+	{
+		return ((m[i].getAttributeTag()==AttributeType1  || m[i].getAttributeTag()==AttributeType2)?false:true);
 	}
 
 };

--- a/include/LeMonADE/utility/DepthIteratorPredicates.h
+++ b/include/LeMonADE/utility/DepthIteratorPredicates.h
@@ -50,7 +50,7 @@ along with LeMonADE.  If not, see <http://www.gnu.org/licenses/>.
 struct belongsToLinearStrand {
 	template<class MoleculesType>
 	bool operator()(const MoleculesType& m, int i)
-			{
+	{
 		return ((m.getNumLinks(i) > 0) && (m.getNumLinks(i) < 3));
 	}
 };
@@ -70,7 +70,7 @@ struct alwaysTrue
 {
 	template<class MoleculesType>
 	bool operator()(const MoleculesType& m, int i)
-			{
+	{
 		return true;
 	}
 };
@@ -90,7 +90,7 @@ struct hasBonds
 {
 	template<class MoleculesType>
 	bool operator()(const MoleculesType& m, int i)
-			{
+	{
 		return m.getNumLinks(i) >0;
 	}
 };
@@ -107,19 +107,19 @@ struct hasBonds
  * @todo Rename FunctorHasThisType
  **/
 template<int AttributeType>
-class hasType
+class hasThisType
 {
 public:
   
 	template<class MoleculesType>
 	bool operator()(const MoleculesType& m, int i)
 	{
-		return (m[i].getAttributeTag()==AttributeType?true:false);
+		return ( (m[i].getAttributeTag()==AttributeType)?true:false );
 	}
 };
 
 /**
- * @class hasOneOfTheseTypes
+ * @class hasOneOfTheseTwoTypes
  *
  * @brief Functor providing the information the Vertex has an attribute tag.
  *
@@ -130,14 +130,14 @@ public:
  * @todo Rename FunctorHasOneOfTheseTypes
  **/
 template<int AttributeType1,int AttributeType2>
-class hasType
+class hasOneOfTheseTwoTypes
 {
 public:
   
 	template<class MoleculesType>
 	bool operator()(const MoleculesType& m, int i)
 	{
-		return ((m[i].getAttributeTag()==AttributeType1  || m[i].getAttributeTag()==AttributeType2)?true:false);
+		return (( (m[i].getAttributeTag()==AttributeType1)  || (m[i].getAttributeTag()==AttributeType2) )?true:false);
 	}
 };
 
@@ -161,7 +161,7 @@ public:
 	template<class MoleculesType>
 	bool operator()(const MoleculesType& m, int i)
 	{
-		return (m[i].getAttributeTag()==AttributeType?false:true);
+		return ( (m[i].getAttributeTag()==AttributeType)?false:true );
 	}
 
 };
@@ -185,7 +185,7 @@ public:
 	template<class MoleculesType>
 	bool operator()(const MoleculesType& m, int i)
 	{
-		return ((m[i].getAttributeTag()==AttributeType1  || m[i].getAttributeTag()==AttributeType2)?false:true);
+		return (( (m[i].getAttributeTag()==AttributeType1)  || (m[i].getAttributeTag()==AttributeType2) )?false:true);
 	}
 
 };

--- a/tests/utility/TestDepthIterator.cpp
+++ b/tests/utility/TestDepthIterator.cpp
@@ -28,11 +28,35 @@ along with LeMonADE.  If not, see <http://www.gnu.org/licenses/>.
 #include "gtest/gtest.h"
 
 #include <LeMonADE/utility/DepthIterator.h>
+#include <LeMonADE/core/Ingredients.h>
 #include <LeMonADE/core/Molecules.h>
+#include <LeMonADE/utility/MonomerGroup.h>
+
+#include <LeMonADE/feature/FeatureAttributes.h>
 
 using namespace std;
 
-TEST( TestGraphIteratorDepthFirst, Iteration )
+class TestDepthIterator: public ::testing::Test{
+public:
+
+  //redirect cout output
+  virtual void SetUp(){
+    originalBuffer=std::cout.rdbuf();
+    std::cout.rdbuf(tempStream.rdbuf());
+  };
+
+  //restore original output
+  virtual void TearDown(){
+    std::cout.rdbuf(originalBuffer);
+  };
+
+private:
+  std::streambuf* originalBuffer;
+  std::ostringstream tempStream;
+};
+
+
+TEST_F( TestDepthIterator, Iteration )
 {
 	typedef Molecules < VectorInt3, 3 > GraphType;
 
@@ -86,6 +110,252 @@ TEST( TestGraphIteratorDepthFirst, Iteration )
 	++iter3; EXPECT_TRUE(iter3.isEnd());
 
 	/// @todo test predicated walks also.
+}
+
+TEST_F( TestDepthIterator, DepthIteratorPredicates )
+{
+  typedef LOKI_TYPELIST_1(FeatureAttributes) Features;
+  typedef ConfigureSystem<VectorInt3,Features> Config;
+  typedef Ingredients<Config> IngredientsType;
+  
+  IngredientsType ingredients;
+  
+  // add some tags
+  ingredients.modifyMolecules().resize(8);
+  ingredients.modifyMolecules()[0].setAttributeTag(1);
+  ingredients.modifyMolecules()[1].setAttributeTag(2);
+  ingredients.modifyMolecules()[2].setAttributeTag(5);
+  ingredients.modifyMolecules()[3].setAttributeTag(4);
+  ingredients.modifyMolecules()[4].setAttributeTag(3);
+  ingredients.modifyMolecules()[5].setAttributeTag(1);
+  ingredients.modifyMolecules()[6].setAttributeTag(3);
+  ingredients.modifyMolecules()[7].setAttributeTag(3);
+  
+  //add some positions
+  ingredients.modifyMolecules()[0].setAllCoordinates(0,0,0);
+  ingredients.modifyMolecules()[1].setAllCoordinates(0,0,2);
+  ingredients.modifyMolecules()[2].setAllCoordinates(0,0,4);
+  ingredients.modifyMolecules()[3].setAllCoordinates(0,0,6);
+  ingredients.modifyMolecules()[4].setAllCoordinates(0,0,8);
+  ingredients.modifyMolecules()[5].setAllCoordinates(0,0,10);
+  ingredients.modifyMolecules()[6].setAllCoordinates(0,0,12);
+  ingredients.modifyMolecules()[7].setAllCoordinates(0,0,14);
+  
+  //connect all to stay within one molecule
+  ingredients.modifyMolecules().connect(0,1);
+  ingredients.modifyMolecules().connect(1,2);
+  ingredients.modifyMolecules().connect(2,3);
+  ingredients.modifyMolecules().connect(3,4);
+  ingredients.modifyMolecules().connect(4,5);
+  ingredients.modifyMolecules().connect(5,6);
+  ingredients.modifyMolecules().connect(6,7);
+  
+  // setup monomer groups vector
+  typedef std::vector < MonomerGroup<IngredientsType::molecules_type> > MonomerGroupVectorType;
+  
+  MonomerGroupVectorType groupsVector;
+  
+  // use fill_connected_groups to create monomer groups 
+  // test hasThisType of unconnected monomers
+  fill_connected_groups(ingredients.getMolecules(), groupsVector, ingredients.getMolecules(), hasThisType<1>());
+  EXPECT_EQ(groupsVector.size(),2);
+  EXPECT_EQ(groupsVector.at(0).size(),1);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(0),0);
+  EXPECT_EQ(groupsVector.at(1).size(),1);
+  EXPECT_EQ(groupsVector.at(1).trueIndex(0),5);
+  
+  // test hasThisType of connected monomers
+  groupsVector.clear();
+  fill_connected_groups(ingredients.getMolecules(), groupsVector, ingredients.getMolecules(), hasThisType<3>());
+  EXPECT_EQ(groupsVector.size(),2);
+  EXPECT_EQ(groupsVector.at(0).size(),1);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(0),4);
+  EXPECT_EQ(groupsVector.at(1).size(),2);
+  EXPECT_EQ(groupsVector.at(1).trueIndex(0),6);
+  EXPECT_EQ(groupsVector.at(1).trueIndex(1),7);
+  
+  // test hasOneOfTheseTwoTypes of unconnected monomers
+  groupsVector.clear();
+  fill_connected_groups(ingredients.getMolecules(), groupsVector, ingredients.getMolecules(), hasOneOfTheseTwoTypes<2,4>());
+  EXPECT_EQ(groupsVector.size(),2);
+  EXPECT_EQ(groupsVector.at(0).size(),1);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(0),1);
+  EXPECT_EQ(groupsVector.at(1).size(),1);
+  EXPECT_EQ(groupsVector.at(1).trueIndex(0),3);
+  
+  // test hasOneOfTheseTwoTypes of connected monomers
+  groupsVector.clear();
+  fill_connected_groups(ingredients.getMolecules(), groupsVector, ingredients.getMolecules(), hasOneOfTheseTwoTypes<1,3>());
+  EXPECT_EQ(groupsVector.size(),2);
+  EXPECT_EQ(groupsVector.at(0).size(),1);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(0),0);
+  EXPECT_EQ(groupsVector.at(1).size(),4);
+  EXPECT_EQ(groupsVector.at(1).trueIndex(0),4);
+  EXPECT_EQ(groupsVector.at(1).trueIndex(1),5);
+  EXPECT_EQ(groupsVector.at(1).trueIndex(2),6);
+  EXPECT_EQ(groupsVector.at(1).trueIndex(3),7);
+  
+  // test notOfBothTypes of connected monomers
+  groupsVector.clear();
+  fill_connected_groups(ingredients.getMolecules(), groupsVector, ingredients.getMolecules(), notOfType<3>());
+  EXPECT_EQ(groupsVector.size(),2);
+  EXPECT_EQ(groupsVector.at(0).size(),4);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(0),0);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(1),1);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(2),2);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(3),3);
+  EXPECT_EQ(groupsVector.at(1).size(),1);
+  EXPECT_EQ(groupsVector.at(1).trueIndex(0),5);
+  
+  // test notOfBothTypes of connected monomers
+  groupsVector.clear();
+  fill_connected_groups(ingredients.getMolecules(), groupsVector, ingredients.getMolecules(), notOfBothTypes<2,4>());
+  EXPECT_EQ(groupsVector.size(),3);
+  EXPECT_EQ(groupsVector.at(0).size(),1);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(0),0);
+  EXPECT_EQ(groupsVector.at(1).size(),1);
+  EXPECT_EQ(groupsVector.at(1).trueIndex(0),2);
+  EXPECT_EQ(groupsVector.at(2).size(),4);
+  EXPECT_EQ(groupsVector.at(2).trueIndex(0),4);
+  EXPECT_EQ(groupsVector.at(2).trueIndex(1),5);
+  EXPECT_EQ(groupsVector.at(2).trueIndex(2),6);
+  EXPECT_EQ(groupsVector.at(2).trueIndex(3),7);
+  
+  // test alwaysTrue of connected monomers
+  groupsVector.clear();
+  fill_connected_groups(ingredients.getMolecules(), groupsVector, ingredients.getMolecules(), alwaysTrue());
+  EXPECT_EQ(groupsVector.size(),1);
+  EXPECT_EQ(groupsVector.at(0).size(),8);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(0),0);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(1),1);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(2),2);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(3),3);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(4),4);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(5),5);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(6),6);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(7),7);
+  
+  // test belongsToLinearStrand of connected monomers
+  groupsVector.clear();
+  fill_connected_groups(ingredients.getMolecules(), groupsVector, ingredients.getMolecules(), belongsToLinearStrand());
+  EXPECT_EQ(groupsVector.size(),1);
+  EXPECT_EQ(groupsVector.at(0).size(),8);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(0),0);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(1),1);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(2),2);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(3),3);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(4),4);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(5),5);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(6),6);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(7),7);
+  
+  // test hasBonds of connected monomers
+  groupsVector.clear();
+  fill_connected_groups(ingredients.getMolecules(), groupsVector, ingredients.getMolecules(), hasBonds());
+  EXPECT_EQ(groupsVector.size(),1);
+  EXPECT_EQ(groupsVector.at(0).size(),8);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(0),0);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(1),1);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(2),2);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(3),3);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(4),4);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(5),5);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(6),6);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(7),7);
+  
+  // change connectivities and redo the last three tests
+  ingredients.modifyMolecules().disconnect(6,7);
+  
+  // test alwaysTrue of connected monomers
+  groupsVector.clear();
+  fill_connected_groups(ingredients.getMolecules(), groupsVector, ingredients.getMolecules(), alwaysTrue());
+  EXPECT_EQ(groupsVector.size(),2);
+  EXPECT_EQ(groupsVector.at(0).size(),7);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(0),0);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(1),1);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(2),2);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(3),3);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(4),4);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(5),5);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(6),6);
+  EXPECT_EQ(groupsVector.at(1).size(),1);
+  EXPECT_EQ(groupsVector.at(1).trueIndex(0),7);
+  
+  // test belongsToLinearStrand of connected monomers
+  groupsVector.clear();
+  fill_connected_groups(ingredients.getMolecules(), groupsVector, ingredients.getMolecules(), belongsToLinearStrand());
+  EXPECT_EQ(groupsVector.size(),1);
+  EXPECT_EQ(groupsVector.at(0).size(),7);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(0),0);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(1),1);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(2),2);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(3),3);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(4),4);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(5),5);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(6),6);
+  
+  // test hasBonds of connected monomers
+  groupsVector.clear();
+  fill_connected_groups(ingredients.getMolecules(), groupsVector, ingredients.getMolecules(), hasBonds());
+  EXPECT_EQ(groupsVector.size(),1);
+  EXPECT_EQ(groupsVector.at(0).size(),7);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(0),0);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(1),1);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(2),2);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(3),3);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(4),4);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(5),5);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(6),6);
+ 
+  // change connectivities and redo the last three tests
+  ingredients.modifyMolecules().connect(6,7);
+  ingredients.modifyMolecules().connect(3,4);
+  
+  // test alwaysTrue of connected monomers
+  groupsVector.clear();
+  fill_connected_groups(ingredients.getMolecules(), groupsVector, ingredients.getMolecules(), alwaysTrue());
+  EXPECT_EQ(groupsVector.size(),2);
+  EXPECT_EQ(groupsVector.at(0).size(),4);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(0),0);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(1),1);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(2),2);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(3),3);
+  EXPECT_EQ(groupsVector.at(1).size(),4);
+  EXPECT_EQ(groupsVector.at(1).trueIndex(0),4);
+  EXPECT_EQ(groupsVector.at(1).trueIndex(1),5);
+  EXPECT_EQ(groupsVector.at(1).trueIndex(2),6);
+  EXPECT_EQ(groupsVector.at(1).trueIndex(3),7);
+  
+  // test belongsToLinearStrand of connected monomers
+  groupsVector.clear();
+  fill_connected_groups(ingredients.getMolecules(), groupsVector, ingredients.getMolecules(), belongsToLinearStrand());
+  EXPECT_EQ(groupsVector.size(),2);
+  EXPECT_EQ(groupsVector.at(0).size(),4);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(0),0);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(1),1);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(2),2);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(3),3);
+  EXPECT_EQ(groupsVector.at(1).size(),4);
+  EXPECT_EQ(groupsVector.at(1).trueIndex(0),4);
+  EXPECT_EQ(groupsVector.at(1).trueIndex(1),5);
+  EXPECT_EQ(groupsVector.at(1).trueIndex(2),6);
+  EXPECT_EQ(groupsVector.at(1).trueIndex(3),7);
+  
+  // test hasBonds of connected monomers
+  groupsVector.clear();
+  fill_connected_groups(ingredients.getMolecules(), groupsVector, ingredients.getMolecules(), hasBonds());
+  EXPECT_EQ(groupsVector.size(),2);
+  EXPECT_EQ(groupsVector.at(0).size(),4);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(0),0);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(1),1);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(2),2);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(3),3);
+  EXPECT_EQ(groupsVector.at(1).size(),4);
+  EXPECT_EQ(groupsVector.at(1).trueIndex(0),4);
+  EXPECT_EQ(groupsVector.at(1).trueIndex(1),5);
+  EXPECT_EQ(groupsVector.at(1).trueIndex(2),6);
+  EXPECT_EQ(groupsVector.at(1).trueIndex(3),7);
+  
 }
 
 /// @todo test generate_connected_groups.

--- a/tests/utility/TestDepthIterator.cpp
+++ b/tests/utility/TestDepthIterator.cpp
@@ -309,7 +309,7 @@ TEST_F( TestDepthIterator, DepthIteratorPredicates )
  
   // change connectivities and redo the last three tests
   ingredients.modifyMolecules().connect(6,7);
-  ingredients.modifyMolecules().connect(3,4);
+  ingredients.modifyMolecules().disconnect(3,4);
   
   // test alwaysTrue of connected monomers
   groupsVector.clear();
@@ -355,7 +355,43 @@ TEST_F( TestDepthIterator, DepthIteratorPredicates )
   EXPECT_EQ(groupsVector.at(1).trueIndex(1),5);
   EXPECT_EQ(groupsVector.at(1).trueIndex(2),6);
   EXPECT_EQ(groupsVector.at(1).trueIndex(3),7);
+ 
+  // add a very simple branch
+  ingredients.modifyMolecules().resize(9);
+  ingredients.modifyMolecules()[8].setAttributeTag(3);
+  ingredients.modifyMolecules()[0].setAllCoordinates(0,2,12);
+  ingredients.modifyMolecules().connect(6,8);
+  ingredients.modifyMolecules().connect(3,4);
   
+  groupsVector.clear();
+  fill_connected_groups(ingredients.getMolecules(), groupsVector, ingredients.getMolecules(), belongsToLinearStrand());
+  EXPECT_EQ(groupsVector.size(),3);
+  EXPECT_EQ(groupsVector.at(0).size(),6);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(0),0);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(1),1);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(2),2);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(3),3);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(4),4);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(5),5);
+  EXPECT_EQ(groupsVector.at(1).size(),1);
+  EXPECT_EQ(groupsVector.at(1).trueIndex(0),7);
+  EXPECT_EQ(groupsVector.at(2).size(),1);
+  EXPECT_EQ(groupsVector.at(2).trueIndex(0),8);
+  
+  // now always true and belongsToLinearStrand should differ
+  groupsVector.clear();
+  fill_connected_groups(ingredients.getMolecules(), groupsVector, ingredients.getMolecules(), alwaysTrue());
+  EXPECT_EQ(groupsVector.size(),1);
+  EXPECT_EQ(groupsVector.at(0).size(),9);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(0),0);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(1),1);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(2),2);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(3),3);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(4),4);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(5),5);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(6),6);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(7),7);
+  EXPECT_EQ(groupsVector.at(0).trueIndex(8),8);
 }
 
 /// @todo test generate_connected_groups.

--- a/tests/utility/TestRandomNumberGenerators.cpp
+++ b/tests/utility/TestRandomNumberGenerators.cpp
@@ -138,8 +138,8 @@ TEST(RandomNumberGeneratorsTest,R250BitsUsage){
 	//check that all bits have been used are within 3sigma of the expectation
 	//value. this test may of course fail
 	for(size_t n=0;n<32;n++){
-		EXPECT_LE(bitUsage[n],(10000+200));
-		EXPECT_GE(bitUsage[n],(10000-200));
+		EXPECT_LE(bitUsage[n],(10000+300));
+		EXPECT_GE(bitUsage[n],(10000-300));
 	}
 
 


### PR DESCRIPTION
Small changes in utility:
- removed old, not working hasType implementation in DepthIteratorPredicates
- added template<int type> hasType, template<int type1, int type2> hasTypes, template<int type1, int type2> notOfTypes like predicators