### PR TITLE
Quelch Warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,26 +3,26 @@
 #   o\.|./o    e   xtensible     | LeMonADE: An Open Source Implementation of the
 #  o\.\|/./o   Mon te-Carlo      |           Bond-Fluctuation-Model for Polymers
 # oo---0---oo  A   lgorithm and  |
-#  o/./|\.\o   D   evelopment    | Copyright (C) 2013-2015 by 
+#  o/./|\.\o   D   evelopment    | Copyright (C) 2013-2015 by
 #   o/.|.\o    E   nvironment    | LeMonADE Principal Developers (see AUTHORS)
-#     ooo                        | 
+#     ooo                        |
 # ---------------------------------------------------------------------------------
 #
 # This file is part of LeMonADE.
-# 
+#
 # LeMonADE is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # LeMonADE is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with LeMonADE.  If not, see <http://www.gnu.org/licenses/>.
-# 
+#
 # --------------------------------------------------------------------------------
 #
 # Project Properties
@@ -48,16 +48,16 @@ SET (APPLICATION_ID "${APPLICATION_VENDOR_ID}.${PROJECT_NAME}")
 SET (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -msse2 -mssse3 -fexpensive-optimizations ")
 SET (CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O3 -msse2 -mssse3 -fexpensive-optimizations ")
 
-SET (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -Wall -DDEBUG ")
-SET (CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O0 -Wall -DDEBUG ")
+SET (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -Wall -Wextra -DDEBUG ")
+SET (CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O0 -Wall -Wextra -DDEBUG ")
 
 #define value of CMAKE_BUILD_TYPE depending on input
 IF(NOT CMAKE_BUILD_TYPE)
 SET (CMAKE_BUILD_TYPE "Release") #default build type is Release
 ELSEIF(CMAKE_BUILD_TYPE STREQUAL "Release")
-SET (CMAKE_BUILD_TYPE "Release") 
+SET (CMAKE_BUILD_TYPE "Release")
 ELSEIF(CMAKE_BUILD_TYPE STREQUAL "Debug")
-SET (CMAKE_BUILD_TYPE "Debug") 
+SET (CMAKE_BUILD_TYPE "Debug")
 ELSE(NOT CMAKE_BUILD_TYPE)
 MESSAGE(FATAL_ERROR "Invalid build type ${CMAKE_BUILD_TYPE} specified.")
 ENDIF(NOT CMAKE_BUILD_TYPE)

--- a/include/LeMonADE/analyzer/AnalyzerRadiusOfGyration.h
+++ b/include/LeMonADE/analyzer/AnalyzerRadiusOfGyration.h
@@ -122,10 +122,10 @@ AnalyzerRadiusOfGyration<IngredientsType>::AnalyzerRadiusOfGyration(
 	const IngredientsType& ing,
 	std::string filename)
 :ingredients(ing)
+,Rg2TimeSeries(4,std::vector<double>(0))
 ,bufferSize(100)
 ,outputFile(filename)
 ,isFirstFileDump(true)
-,Rg2TimeSeries(4,std::vector<double>(0))
 {
 }
 

--- a/include/LeMonADE/core/ConnectedDecorator.h
+++ b/include/LeMonADE/core/ConnectedDecorator.h
@@ -216,9 +216,10 @@ void Connected<Vertex,max_connectivity>::connect(int32_t b) {
 	for (uint32_t i = 0; i < counter; i++)
 	{
 		if (((uint32_t)b) == links[i]){
-#ifdef DEBUG
+/*#ifdef DEBUG
 			std::cerr<< "Connected::connect(unit b): Vertices already connected" << std::endl;
 #endif	// End DEBUG
+			/*  */
 			return;
 		}
 	}

--- a/include/LeMonADE/core/ConnectedDecorator.h
+++ b/include/LeMonADE/core/ConnectedDecorator.h
@@ -213,7 +213,7 @@ void Connected<Vertex,max_connectivity>::connect(int32_t b) {
 		throw std::runtime_error("Connected::connect(uint b): b < 0");
 	}
 	// check whether object b is already connected to me
-	for (int i = 0; i < counter; i++)
+	for (uint32_t i = 0; i < counter; i++)
 	{
 		if (((uint32_t)b) == links[i]){
 #ifdef DEBUG

--- a/include/LeMonADE/core/Ingredients.h
+++ b/include/LeMonADE/core/Ingredients.h
@@ -293,7 +293,7 @@ public:
 	std::string getSumOfComments() const
 	{
 		std::string SumOfComments;
-		for (int i=0; i<comments.size(); ++i){
+		for (size_t i=0; i<comments.size(); ++i){
 			SumOfComments += comments[i];
 		}
 		return SumOfComments;

--- a/include/LeMonADE/core/Molecules.h
+++ b/include/LeMonADE/core/Molecules.h
@@ -133,7 +133,7 @@ template < class Vertex, uint max_connectivity = 7, class Edge = int > class Mol
    *
    * @return The actual time in the graph.
    */
-  const uint64_t 	getAge() const 			{return myAge;}
+  uint64_t 	getAge() const 			{return myAge;}
 
   /**
    * @brief Sets the actual time to a given value \a newAge in the graph.

--- a/include/LeMonADE/core/MoleculesRead.h
+++ b/include/LeMonADE/core/MoleculesRead.h
@@ -321,7 +321,7 @@ template < class IngredientsType > void ReadMcs< IngredientsType >::execute()
   }
 
   //if total number of monomers in !mcs differs from previous, throw exception
-  if(monomerCount!=molecules.size()){
+  if((uint32_t)monomerCount!=molecules.size()){
 
     std::stringstream errormessage;
     errormessage<<"ReadMcs<IngredientsType>::execute()\n"

--- a/include/LeMonADE/feature/Feature.h
+++ b/include/LeMonADE/feature/Feature.h
@@ -86,10 +86,10 @@ public:
   typedef ::Loki::NullType monomer_extensions;
 
   //! Export the relevant functionality for reading bfm-files to the responsible reader object
-  template < class FileRead  > void exportRead ( FileRead & file){}
+  template < class FileRead  > void exportRead ( FileRead & ){}
 
   //! Export the relevant functionality for writing bfm-files to the responsible writer object
-  template < class FileWrite > void exportWrite( FileWrite& file) const {}
+  template < class FileWrite > void exportWrite( FileWrite& ) const {}
 
 
   /**
@@ -101,7 +101,7 @@ public:
    * @param [in] move General move (maybe MoveLocalSc or MoveLocalBcc).
    * @return true Always!
    */
-  template < class IngredientsType> bool checkMove( const IngredientsType& ingredients, const MoveBase& move ) const{ return true; }
+  template < class IngredientsType> bool checkMove( const IngredientsType&, const MoveBase& ) const{ return true; }
 
   /**
    * @brief Apply all Move. Does Nothing.
@@ -112,7 +112,7 @@ public:
    * @param [in] ingredients A reference to the IngredientsType - mainly the system
    * @param [in] move General move (maybe MoveLocalSc or MoveLocalBcc).
    */
-  template < class IngredientsType> void applyMove( IngredientsType& ingredients, const MoveBase& move ) { }
+  template < class IngredientsType> void applyMove( IngredientsType&, const MoveBase& ) { }
 
   /**
    * @brief Synchronizes the Features and establishing consistency in the system.
@@ -125,7 +125,7 @@ public:
    *
    * @param ingredients A reference to the IngredientsType - mainly the system.
    */
-  template < class IngredientsType > void synchronize(IngredientsType& ingredients) {};
+  template < class IngredientsType > void synchronize(IngredientsType&) {};
 
   /**
    * @brief Overloaded function to stream all metadata to an output stream.
@@ -135,7 +135,7 @@ public:
    *
    * @param stream output stream
    */
-  virtual void printMetaData(std::ostream& stream) const{}
+  virtual void printMetaData(std::ostream&) const{}
 
 
 };

--- a/include/LeMonADE/feature/FeatureAttributes.h
+++ b/include/LeMonADE/feature/FeatureAttributes.h
@@ -125,7 +125,7 @@ public:
 
   //! For all unknown moves: this does nothing
   template<class IngredientsType>
-    void applyMove(IngredientsType& ing, const MoveBase& move){};
+    void applyMove(IngredientsType&, const MoveBase&){};
 
   //! Overloaded for moves of type MoveAddMonomerBase to set the attribute tag by inserting a monomer
   template<class IngredientsType,class AddMoveType>

--- a/include/LeMonADE/feature/FeatureLatticeBase.h
+++ b/include/LeMonADE/feature/FeatureLatticeBase.h
@@ -355,7 +355,7 @@ void FeatureLatticeBase<SpecializedClass<ValueType> >::setupLattice()
 	// Allocate memory
 	lattice = new ValueType[_boxX*_boxY*_boxZ];
 
-	for(int i = 0; i < _boxX*_boxY*_boxZ; i++)
+	for(uint32_t i = 0; i < _boxX*_boxY*_boxZ; i++)
 		lattice[i]=ValueType();
 
 	std::cout<<"done with size " << (_boxX*_boxY*_boxZ*sizeof(ValueType)) << " bytes = " << (_boxX*_boxY*_boxZ*sizeof(ValueType)/(1024.0*1024.0)) << " MB for lattice" <<std::endl;
@@ -392,7 +392,7 @@ void FeatureLatticeBase<SpecializedClass<ValueType> >::setupLattice(uint32_t box
 	// Allocate memory
 	lattice = new ValueType[_boxX*_boxY*_boxZ];
 
-	for(int i = 0; i < _boxX*_boxY*_boxZ; i++)
+	for(uint32_t i = 0; i < _boxX*_boxY*_boxZ; i++)
 		lattice[i]=ValueType();
 
 	std::cout<<"done with size " << (_boxX*_boxY*_boxZ*sizeof(ValueType)) << " bytes = " << (_boxX*_boxY*_boxZ*sizeof(ValueType)/(1024.0*1024.0)) << " MB for lattice" <<std::endl;
@@ -409,7 +409,7 @@ void FeatureLatticeBase<SpecializedClass<ValueType> >::clearLattice()
 {
 
 	// initialize to native value (=0)
-	for(int i = 0; i < _boxX*_boxY*_boxZ; i++)
+	for(uint32_t i = 0; i < _boxX*_boxY*_boxZ; i++)
 		lattice[i]=ValueType();
 }
 

--- a/include/LeMonADE/feature/FeatureLatticePowerOfTwo.h
+++ b/include/LeMonADE/feature/FeatureLatticePowerOfTwo.h
@@ -266,11 +266,11 @@ void FeatureLatticePowerOfTwo<ValueType>::synchronize(IngredientsType& val) {
 		}
 		this->proXY=resultshift;
 
-		std::cout << "use bit shift for boxX: (1 << "<< this->xPro << " ) = " << (1 << this->xPro) << " = " << (this->_boxX) << std::endl;
-		std::cout << "use bit shift for boxX*boxY: (1 << "<< this->proXY << " ) = " << (1 << this->proXY) << " = " << (this->_boxX*this->_boxY) << std::endl;
+		std::cout << "use bit shift for boxX: (1 << "<< this->xPro << " ) = " << (1u << this->xPro) << " = " << (this->_boxX) << std::endl;
+		std::cout << "use bit shift for boxX*boxY: (1 << "<< this->proXY << " ) = " << (1u << this->proXY) << " = " << (this->_boxX*this->_boxY) << std::endl;
 
 		// check if shift is correct
-		if ( (this->_boxX != (1 << this->xPro)) || ((this->_boxX*this->_boxY) != (1 << this->proXY)) )
+		if ( (this->_boxX != (1u << this->xPro)) || ((this->_boxX*this->_boxY) != (1u << this->proXY)) )
 		{
 			throw  std::runtime_error("Could not determine value for bit shift. Sure your box size is a power of 2?\nl Use feature FeatureLattice instead of FeatureLatticePowerOfTwo\n");
 		}

--- a/include/LeMonADE/io/AbstractWrite.h
+++ b/include/LeMonADE/io/AbstractWrite.h
@@ -72,7 +72,7 @@ public:
   AbstractWrite(const Source& src):src(src){}
   virtual ~AbstractWrite(){}
 
-  virtual void writeStream(std::ostream& strm) {};
+  virtual void writeStream(std::ostream&) {};
 
   const Source& getSource() const {return src;}
 protected:

--- a/include/LeMonADE/updater/UpdaterSimpleSimulator.h
+++ b/include/LeMonADE/updater/UpdaterSimpleSimulator.h
@@ -73,9 +73,9 @@ public:
 	time_t startTimer = time(NULL); //in seconds
 	std::cout<<"mcs "<<ingredients.getMolecules().getAge() << " passed time " << ((difftime(time(NULL), startTimer)) ) <<std::endl;
 
-    for(int n=0;n<nsteps;n++){
+    for(uint32_t n=0;n<nsteps;n++){
 
-	for(int m=0;m<ingredients.getMolecules().size();m++)
+	for(size_t m=0;m<ingredients.getMolecules().size();m++)
 	{
 		move.init(ingredients);
 

--- a/include/LeMonADE/utility/MonomerGroup.h
+++ b/include/LeMonADE/utility/MonomerGroup.h
@@ -80,7 +80,7 @@ public:
 
   MonomerGroup& operator = (const MonomerGroup& src) {
     this->moleculesGroup = src.moleculesGroup;
-    this-> indices = src.indices;
+    this->indices = src.indices;
   }
 
   size_t size() const { return indices.size();}

--- a/include/LeMonADE/utility/MonomerGroup.h
+++ b/include/LeMonADE/utility/MonomerGroup.h
@@ -88,7 +88,7 @@ public:
 
   int trueIndex( int i ) const {return indices.at(i);}
 
-  const uint64_t getAge() const {return moleculesGroup->getAge();}
+  uint64_t getAge() const {return moleculesGroup->getAge();}
 
   MoleculesType copyGroup() const;
 

--- a/include/LeMonADE/utility/MonomerGroup.h
+++ b/include/LeMonADE/utility/MonomerGroup.h
@@ -81,6 +81,7 @@ public:
   MonomerGroup& operator = (const MonomerGroup& src) {
     this->moleculesGroup = src.moleculesGroup;
     this->indices = src.indices;
+    return *this;
   }
 
   size_t size() const { return indices.size();}

--- a/include/LeMonADE/utility/ResultFormattingTools.h
+++ b/include/LeMonADE/utility/ResultFormattingTools.h
@@ -112,14 +112,14 @@ void ResultFormattingTools::writeTable(std::ostream& stream,
 	stream << commentStream.str() << std::endl;
 
 	//check if all column have the same size
-	int columnSize = results[0].size();
-	for (int i = 0; i < results.size(); ++i) {
+	size_t columnSize = results[0].size();
+	for (size_t i = 0; i < results.size(); ++i) {
 		if (results[i].size() != columnSize)
 			throw std::runtime_error("ResultFormattingTools::writeTable():Columns do not have the same size\n");
 	}
 
-	for (int row = 0; row < results[0].size(); ++row) {
-		for (int column = 0; column < results.size(); ++column) {
+	for (size_t row = 0; row < results[0].size(); ++row) {
+		for (size_t column = 0; column < results.size(); ++column) {
 			stream << results[column][row] << "\t";
 		}
 		stream << std::endl;
@@ -164,8 +164,8 @@ void ResultFormattingTools::appendToResultFile(std::string filename,ResultType& 
 		throw std::runtime_error("ResultFormattingTools::appendToResultFile(): error opening output file"+filename+"\n");
 
 	//check if all column have the same size
-	int columnSize = results[0].size();
-	for (int i = 0; i < results.size(); ++i) {
+	size_t columnSize = results[0].size();
+	for (size_t i = 0; i < results.size(); ++i) {
 		if (results[i].size() != columnSize){
 			std::stringstream errormessage;
 			errormessage<<"ResultFormattingTools::appendToResultFile():Columns do not have the same size\n";
@@ -175,8 +175,8 @@ void ResultFormattingTools::appendToResultFile(std::string filename,ResultType& 
 	}
 
 	//write content
-	for (int row = 0; row < results[0].size(); ++row) {
-		for (int column = 0; column < results.size(); ++column) {
+	for (size_t row = 0; row < results[0].size(); ++row) {
+		for (size_t column = 0; column < results.size(); ++column) {
 			file << results[column][row] << "\t";
 		}
 		file << std::endl;

--- a/projects/Examples/example0/ex0main.cpp
+++ b/projects/Examples/example0/ex0main.cpp
@@ -36,8 +36,8 @@ along with LeMonADE.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <LeMonADE/utility/Vector3D.h>
 
-int main(int argc, char* argv[]){
-
+int main(int, char**)
+{
   /* ********************************************************************
    * Vector3D is a class template with the template parameter specifying
    * the underlying basic data type. For example:
@@ -139,5 +139,4 @@ int main(int argc, char* argv[]){
    ***********************************************************************/
 
   return 0;
-
 }

--- a/projects/Examples/example1/ex1main.cpp
+++ b/projects/Examples/example1/ex1main.cpp
@@ -33,10 +33,8 @@ along with LeMonADE.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <LeMonADE/utility/RandomNumberGenerators.h>
 
-int main(int argc, char* argv[]){
-
-
-
+int main(int, char**)
+{
 	/* ****************************************************************
 	* The class RandomNumberGenerators provides an interface for
 	* seeding the provided random number generators with a random

--- a/projects/Examples/example2/ex2main.cpp
+++ b/projects/Examples/example2/ex2main.cpp
@@ -28,7 +28,7 @@ along with LeMonADE.  If not, see <http://www.gnu.org/licenses/>.
 #include <LeMonADE/core/Molecules.h>
 #include <LeMonADE/utility/Vector3D.h>
 
-int main(int argc, char* argv[])
+int main(int, char**)
 {
   /* ***************************************************************************
    * As a first example of how the class Molecules can be used we define a

--- a/projects/Examples/example3/CMakeLists.txt
+++ b/projects/Examples/example3/CMakeLists.txt
@@ -12,4 +12,12 @@ include_directories (${LEMONADE_INCLUDE_DIR})
 link_directories (${LEMONADE_LIBRARY_DIR})
 
 add_executable(Example3 ex3main.cpp)
-target_link_libraries(Example3 LeMonADE)
+if( ( NOT DEFINED project_build_static ) OR ( project_build_static ) )
+    # using the project name set in LeMonADE/src/CMakeLists.txt
+    # instead of the library file name correctly watches out for dependencies
+    # when trying to compile in parallel with make -j
+    target_link_libraries(Example3 libLeMonADE-static)
+else()
+    link_directories ("${CMAKE_BINARY_DIR}/lib/")
+    target_link_libraries(Example3 LeMonADE)
+endif()

--- a/projects/Examples/example3/ex3main.cpp
+++ b/projects/Examples/example3/ex3main.cpp
@@ -41,9 +41,8 @@ along with LeMonADE.  If not, see <http://www.gnu.org/licenses/>.
 #include <LeMonADE/utility/Vector3D.h>
 
 
-int main(int argc, char* argv[])
+int main(int, char**)
 {
-
   /* ***************************************************************************
    * The definition of the Ingredients and the features used can conveniently done
    * using some typedefs at the beginning of the main function. These usually make

--- a/projects/Examples/example4/CMakeLists.txt
+++ b/projects/Examples/example4/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required (VERSION 2.6)
 
-
 if (NOT DEFINED LEMONADE_INCLUDE_DIR)
 message("LEMONADE_INCLUDE_DIR is not provided. If build fails, use -DLEMONADE_INCLUDE_DIR=/path/to/LeMonADE/headers/ or install to default location")
 endif()
@@ -13,5 +12,12 @@ include_directories (${LEMONADE_INCLUDE_DIR})
 link_directories (${LEMONADE_LIBRARY_DIR})
 
 add_executable(Example4 ex4main.cpp)
-target_link_libraries(Example4 LeMonADE)
-
+if( ( NOT DEFINED project_build_static ) OR ( project_build_static ) )
+    # using the project name set in LeMonADE/src/CMakeLists.txt
+    # instead of the library file name correctly watches out for dependencies
+    # when trying to compile in parallel with make -j
+    target_link_libraries(Example4 libLeMonADE-static)
+else()
+    link_directories ("${CMAKE_BINARY_DIR}/lib/")
+    target_link_libraries(Example4 LeMonADE)
+endif()

--- a/projects/Examples/example4/ex4main.cpp
+++ b/projects/Examples/example4/ex4main.cpp
@@ -46,8 +46,8 @@ along with LeMonADE.  If not, see <http://www.gnu.org/licenses/>.
 #include <LeMonADE/updater/moves/MoveLocalSc.h>
 
 
-int main(int argc, char* argv[]){
-
+int main(int, char**)
+{
     /* ****************************************************************
       * as described in the previous examples, we quickly seed the
       * random number generator, and set up a system in a box with the

--- a/projects/Examples/example5/ex5main.cpp
+++ b/projects/Examples/example5/ex5main.cpp
@@ -55,8 +55,8 @@ along with LeMonADE.  If not, see <http://www.gnu.org/licenses/>.
 
 
 
-int main(int argc, char* argv[]){
-
+int main(int, char**)
+{
     /* ****************************************************************
       * the first part looks exactly like in the last example.
       * ***************************************************************/

--- a/src/LeMonADE/utility/FastBondset.cpp
+++ b/src/LeMonADE/utility/FastBondset.cpp
@@ -48,8 +48,8 @@ FastBondset::~FastBondset(){}
  * @param copyBondSet
  */
 FastBondset::FastBondset(const FastBondset& copyBondSet):// Copy the map Bondvectors explicitly
-  lookupSynchronized(false),
-  BondVectors(copyBondSet.BondVectors)
+  BondVectors(copyBondSet.BondVectors),
+  lookupSynchronized(false)
 	    {
 #ifdef DEBUG
 		// check call of copy constructor

--- a/src/LeMonADE/utility/SlowBondset.cpp
+++ b/src/LeMonADE/utility/SlowBondset.cpp
@@ -45,7 +45,7 @@ SlowBondset::SlowBondset():bondsetLookup(0),lookupOffset(0){}
  * @param copyBondSet
  */
 SlowBondset::SlowBondset(const SlowBondset& copyBondSet):
-  lookupOffset(copyBondSet.lookupOffset)
+  FastBondset(), lookupOffset(copyBondSet.lookupOffset)
 	    {
 #ifdef DEBUG
 		// check call of copy constructor
@@ -57,8 +57,6 @@ SlowBondset::SlowBondset(const SlowBondset& copyBondSet):
 	        // perform the lookup update
 		  // set manually field pointer to 0 to avoid memory leak
 		this->bondsetLookup=NULL;
-		  // set synchronized bool to false to refresh lookup
-		this->lookupSynchronized=false;
 		  // perform the reset
 		this->updateLookupTable();
 	    }


### PR DESCRIPTION
This squelches some warnings in debug mode which distract when trying to find problems in new projects. Instead of deleting variable names on unused params warnings, I also tend to comment them out with /**/ if the name adds an insightful description. Also the CMakeLists.txt file seem to still contain trailing spaces, I fogot them in my find command in one of my earlier pull requests, they got auto deleted by my editor.
Edit: yes, I failed to spell 'squelch' correctly in the commit messages.