### PR TITLE
Add CircleCi config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,24 @@
+version: 2
+
+jobs:
+  build:
+    docker:
+      - image: "ubuntu:bionic"
+    environment:
+      TEST_RESULTS: /tmp/test-results/LeMonADE
+    steps:
+      - checkout
+      - run:
+          name: Installing Dependencies
+          command: 'apt-get update && apt-get install -y build-essential cmake git'
+      - run:
+          name: Configure build
+          command: './configure -DLEMONADE_TESTS=ON'
+      - run:
+          name: Run build
+          command: |
+            export GTEST_OUTPUT=xml:${TEST_RESULTS}/
+            mkdir -p $TEST_RESULTS
+            make
+      - store_test_results:
+          path: /tmp/test-results


### PR DESCRIPTION
Adds a config file for [CircleCi](https://circleci.com). This adds [green checkboxes](https://github.com/vinzBad/LeMonADE/commits/master) to every commit, when the test returns no errors. It also runs for Pull Requests, which is a great way to ensure PRs passing the test suite. 

After merging this PR you'd need to register your github account with circleci and enable it for your repo. 