### PR TITLE
adding a VectorDouble3 overload for distance calculation

### DIFF
--- a/include/LeMonADE/utility/DistanceCalculation.h
+++ b/include/LeMonADE/utility/DistanceCalculation.h
@@ -28,6 +28,11 @@ along with LeMonADE.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef LEMONADE_UTILITY_DISTANCECALCULATION_H
 #define LEMONADE_UTILITY_DISTANCECALCULATION_H
 
+/**
+ * @file
+ * @brief helper functions to calculate distances using the minimum image convention
+ * */
+
 #include <iostream>
 
 #include "extern/loki/NullType.h"
@@ -40,7 +45,6 @@ namespace Lemonade
 {
 
 /**
- * @fn  MinImageDistanceComponentForPowerOfTwo
  * @brief calculates the minimal distances of images for one component 
  * @return int 
  * @param x1 absolute coordinate
@@ -62,7 +66,6 @@ inline int MinImageDistanceComponentForPowerOfTwo(const int x1, const int x2, co
   }
 } 
 /**
- * @fn MinImageVectorForPowerOfTwo
  * @brief returns the shortest vector between two images for a box size of power of 2 
  * @return vector 
  * @param R1 position vector  
@@ -79,7 +82,6 @@ VectorInt3 MinImageVectorForPowerOfTwo (const VectorInt3 R1, const VectorInt3 R2
   return dist;
 }
 /**
- * @fn MinImageDistanceForPowerOfTwo
  * @brief returns the minimal distance between two images for a box size of power of 2 
  * @return double 
  * @param R1 position vector  
@@ -95,7 +97,6 @@ double MinImageDistanceForPowerOfTwo (const VectorInt3 R1, const VectorInt3 R2, 
 // Implementation for arbitrary box dimensions. 
 
 /**
- * @fn  fold
  * @brief helper function to fold back absolute coordinates to relative coordinates 
  * @return uint32_t 
  * @param value absolute coordinate difference
@@ -106,7 +107,6 @@ inline uint32_t fold(int value, int box){
 }
 
 /**
- * @fn  MinImageDistanceComponent
  * @brief calculates the minimal distances of images for an arbitrary box size 
  * @return int 
  * @param x1 absolute coordinate
@@ -119,7 +119,6 @@ inline int MinImageDistanceComponent(const int x1, const int x2, const uint32_t 
 }
 
 /**
- * @fn MinImageVector
  * @brief returns the shortest vector between two images for an arbitrary box size 
  * @return vector 
  * @param R1 position vector  
@@ -138,7 +137,6 @@ VectorInt3 MinImageVector (const VectorInt3 R1, const VectorInt3 R2, Ingredients
 }
 
 /**
- * @fn MinImageDistance
  * @brief returns the minimal distance between two images for an arbitrary box size 
  * @return double 
  * @param R1 position vector  
@@ -147,6 +145,55 @@ VectorInt3 MinImageVector (const VectorInt3 R1, const VectorInt3 R2, Ingredients
  */
 template < class IngredientsType>
 double MinImageDistance (const VectorInt3 R1, const VectorInt3 R2, IngredientsType& ing)
+{
+  return MinImageVector(R1,R2,ing).getLength();
+}
+
+/**
+ * @brief calculates the minimal distances of images for an arbitrary box size 
+ * @return double 
+ * @detail overloaded minimal distance calculation function for double vectors
+ * @param x1 absolute coordinate
+ * @param x2 absolute coordinate
+ * @param LatticeSize size of the box in the direction of the given coordinates
+ */
+inline double MinImageDistanceComponent(const double x1, const double x2, const uint32_t latticeSize )
+{
+  double invBoxSize(1.0/latticeSize);
+  double delta(x1-x2);
+  delta-=latticeSize * nearbyint(delta * invBoxSize);
+  return delta;
+}
+
+/**
+ * @brief returns the shortest vector between two images for an arbitrary box size 
+ * @return vector
+ * @detail overloaded minimal distance calculation function for double vectors
+ * @param R1 position vector  
+ * @param R2 position vector 
+ * @param ing container containing (all) system information
+ */
+template < class IngredientsType>
+VectorDouble3 MinImageVector (const VectorDouble3 R1, const VectorDouble3 R2, IngredientsType& ing)
+{
+  VectorDouble3 dist;
+  
+  ing.isPeriodicX() ? dist.setX(MinImageDistanceComponent(R1.getX(),R2.getX(),ing.getBoxX())) : dist.setX(R2.getX()-R1.getX());
+  ing.isPeriodicY() ? dist.setY(MinImageDistanceComponent(R1.getY(),R2.getY(),ing.getBoxY())) : dist.setY(R2.getY()-R1.getY());
+  ing.isPeriodicZ() ? dist.setZ(MinImageDistanceComponent(R1.getZ(),R2.getZ(),ing.getBoxZ())) : dist.setZ(R2.getZ()-R1.getZ());
+  return dist;
+}
+
+/**
+ * @brief returns the minimal distance between two images for an arbitrary box size 
+ * @detail overloaded minimal distance calculation function for double vectors
+ * @return double 
+ * @param R1 double vector  
+ * @param R2 double vector 
+ * @param ing container containing (all) system information
+ */
+template < class IngredientsType>
+double MinImageDistance (const VectorDouble3 R1, const VectorDouble3 R2, IngredientsType& ing)
 {
   return MinImageVector(R1,R2,ing).getLength();
 }

--- a/include/LeMonADE/utility/DistanceCalculation.h
+++ b/include/LeMonADE/utility/DistanceCalculation.h
@@ -160,7 +160,7 @@ double MinImageDistance (const VectorInt3 R1, const VectorInt3 R2, IngredientsTy
 inline double MinImageDistanceComponent(const double x1, const double x2, const uint32_t latticeSize )
 {
   double invBoxSize(1.0/latticeSize);
-  double delta(x1-x2);
+  double delta(x2-x1);
   delta-=latticeSize * nearbyint(delta * invBoxSize);
   return delta;
 }

--- a/tests/utility/TestDistanceCalculation.cpp
+++ b/tests/utility/TestDistanceCalculation.cpp
@@ -211,37 +211,37 @@ TEST_F( TestDistanceCalculation, DoubleValuesArbitraryBoxes )
 
   //std::cout << CoM1<< " - " << CoM2 << std::endl;
 
-  // diff = (0.5,1.5,11)
+  // diff = (-0.5,-1.5,11)
   vec  = MinImageVector  ( CoM1,CoM2, ing );
-  EXPECT_EQ(VectorDouble3(0.5,1.5,11),vec);
+  EXPECT_EQ(VectorDouble3(-0.5,-1.5,11),vec);
   vec  = MinImageVector  ( CoM2,CoM1, ing );
-  EXPECT_EQ(VectorDouble3(-0.5,-1.5,-11),vec);
+  EXPECT_EQ(VectorDouble3(0.5,1.5,-11),vec);
   dist = MinImageDistance( CoM1,CoM2, ing );
   EXPECT_DOUBLE_EQ(sqrt(0.5*0.5+1.5*1.5+11*11),dist);
 
   ing.setPeriodicZ(true);
   // diff = (0.5,1.5,2)
   vec  = MinImageVector  ( CoM1,CoM2, ing );
-  EXPECT_EQ(VectorDouble3(0.5,1.5,2),vec);
-  vec  = MinImageVector  ( CoM2,CoM1, ing );
   EXPECT_EQ(VectorDouble3(-0.5,-1.5,-2),vec);
+  vec  = MinImageVector  ( CoM2,CoM1, ing );
+  EXPECT_EQ(VectorDouble3(0.5,1.5,2),vec);
   dist = MinImageDistance( CoM1,CoM2, ing );
   EXPECT_DOUBLE_EQ(sqrt(0.5*0.5+1.5*1.5+4),dist);
 
-  // diff = (1.5,0,0)-(3,0,0) = (-1.5,0,0)
+  // diff = (3,0,0)-(1.5,0,0) = (1.5,0,0)
   vec  = MinImageVector  ( CoM1, (VectorDouble3)(mol[1]), ing );
-  EXPECT_EQ(VectorDouble3(-1.5,0,0),vec);
-  vec  = MinImageVector  ( (VectorDouble3)(mol[1]), CoM1, ing );
   EXPECT_EQ(VectorDouble3(1.5,0,0),vec);
+  vec  = MinImageVector  ( (VectorDouble3)(mol[1]), CoM1, ing );
+  EXPECT_EQ(VectorDouble3(-1.5,0,0),vec);
   dist = MinImageDistance( CoM1, (VectorDouble3)(mol[1]), ing );
   EXPECT_DOUBLE_EQ(1.5,dist);
 
   ing.modifyMolecules()[1].modifyVector3D().setAllCoordinates(11,0,0);
-  // diff = (1.5,0,0)-(11,0,0) = (3.5,0,0)
+  // diff = (11,0,0)-(1.5,0,0) = (-3.5,0,0)
   vec  = MinImageVector  ( CoM1, (VectorDouble3)(mol[1]), ing );
-  EXPECT_EQ(VectorDouble3(3.5,0,0),vec);
-  vec  = MinImageVector  ( (VectorDouble3)(mol[1]), CoM1, ing );
   EXPECT_EQ(VectorDouble3(-3.5,0,0),vec);
+  vec  = MinImageVector  ( (VectorDouble3)(mol[1]), CoM1, ing );
+  EXPECT_EQ(VectorDouble3(3.5,0,0),vec);
   dist = MinImageDistance( CoM1, (VectorDouble3)(mol[1]), ing );
   EXPECT_DOUBLE_EQ(3.5,dist);
 

--- a/tests/utility/TestDistanceCalculation.cpp
+++ b/tests/utility/TestDistanceCalculation.cpp
@@ -44,8 +44,8 @@ public:
   typedef Ingredients<Config> Ing;
   
 
-  //redirect cout output
-  
+  //redirect cout output 
+  /*
   virtual void SetUp(){
     originalBuffer=std::cout.rdbuf();
     std::cout.rdbuf(tempStream.rdbuf());
@@ -177,5 +177,72 @@ TEST_F( TestDistanceCalculation, NonPowerOfTwoBoxes )
   EXPECT_EQ(1,dist);
   vec  = MinImageVector  ( mol[0],mol[1], ing );
   EXPECT_EQ(VectorInt3(1,0,0),vec);
+
+}
+
+TEST_F( TestDistanceCalculation, DoubleValuesArbitraryBoxes )
+{
+  ing.setBoxX(13);
+  ing.setPeriodicX(true);
+  ing.setBoxY(13);
+  ing.setPeriodicY(true);
+  ing.setBoxZ(13);
+  ing.setPeriodicZ(false);
+  ing.modifyMolecules().resize(4);
+  ing.modifyMolecules()[0].modifyVector3D().setAllCoordinates(0,0,0);
+  ing.modifyMolecules()[1].modifyVector3D().setAllCoordinates(3,0,0);
+  ing.modifyMolecules()[2].modifyVector3D().setAllCoordinates(0,11,11);
+  ing.modifyMolecules()[3].modifyVector3D().setAllCoordinates(2,12,11);
+
+  
+  Ing::molecules_type const& mol = ing.getMolecules();
+  double dist;
+  VectorDouble3 CoM1,CoM2,vec;
+
+  // (1.5,0,0)
+  CoM1.setX((mol[0].getX()+mol[1].getX())/2.0);
+  CoM1.setY((mol[0].getY()+mol[1].getY())/2.0);
+  CoM1.setZ((mol[0].getZ()+mol[1].getZ())/2.0);
+
+  // (1,11.5,11)
+  CoM2.setX((mol[2].getX()+mol[3].getX())/2.0);
+  CoM2.setY((mol[2].getY()+mol[3].getY())/2.0);
+  CoM2.setZ((mol[2].getZ()+mol[3].getZ())/2.0);
+
+  //std::cout << CoM1<< " - " << CoM2 << std::endl;
+
+  // diff = (0.5,1.5,11)
+  vec  = MinImageVector  ( CoM1,CoM2, ing );
+  EXPECT_EQ(VectorDouble3(0.5,1.5,11),vec);
+  vec  = MinImageVector  ( CoM2,CoM1, ing );
+  EXPECT_EQ(VectorDouble3(-0.5,-1.5,-11),vec);
+  dist = MinImageDistance( CoM1,CoM2, ing );
+  EXPECT_DOUBLE_EQ(sqrt(0.5*0.5+1.5*1.5+11*11),dist);
+
+  ing.setPeriodicZ(true);
+  // diff = (0.5,1.5,2)
+  vec  = MinImageVector  ( CoM1,CoM2, ing );
+  EXPECT_EQ(VectorDouble3(0.5,1.5,2),vec);
+  vec  = MinImageVector  ( CoM2,CoM1, ing );
+  EXPECT_EQ(VectorDouble3(-0.5,-1.5,-2),vec);
+  dist = MinImageDistance( CoM1,CoM2, ing );
+  EXPECT_DOUBLE_EQ(sqrt(0.5*0.5+1.5*1.5+4),dist);
+
+  // diff = (1.5,0,0)-(3,0,0) = (-1.5,0,0)
+  vec  = MinImageVector  ( CoM1, (VectorDouble3)(mol[1]), ing );
+  EXPECT_EQ(VectorDouble3(-1.5,0,0),vec);
+  vec  = MinImageVector  ( (VectorDouble3)(mol[1]), CoM1, ing );
+  EXPECT_EQ(VectorDouble3(1.5,0,0),vec);
+  dist = MinImageDistance( CoM1, (VectorDouble3)(mol[1]), ing );
+  EXPECT_DOUBLE_EQ(1.5,dist);
+
+  ing.modifyMolecules()[1].modifyVector3D().setAllCoordinates(11,0,0);
+  // diff = (1.5,0,0)-(11,0,0) = (3.5,0,0)
+  vec  = MinImageVector  ( CoM1, (VectorDouble3)(mol[1]), ing );
+  EXPECT_EQ(VectorDouble3(3.5,0,0),vec);
+  vec  = MinImageVector  ( (VectorDouble3)(mol[1]), CoM1, ing );
+  EXPECT_EQ(VectorDouble3(-3.5,0,0),vec);
+  dist = MinImageDistance( CoM1, (VectorDouble3)(mol[1]), ing );
+  EXPECT_DOUBLE_EQ(3.5,dist);
 
 }

--- a/tests/utility/TestDistanceCalculation.cpp
+++ b/tests/utility/TestDistanceCalculation.cpp
@@ -244,5 +244,15 @@ TEST_F( TestDistanceCalculation, DoubleValuesArbitraryBoxes )
   EXPECT_EQ(VectorDouble3(3.5,0,0),vec);
   dist = MinImageDistance( CoM1, (VectorDouble3)(mol[1]), ing );
   EXPECT_DOUBLE_EQ(3.5,dist);
-
+  
+  //test for position apart by more than a box size
+  VectorDouble3 vec1(3.5,0.5,0.5);
+  VectorDouble3 vec2(-16.,-12.5,31.5);
+  vec  = MinImageVector  ( vec1, vec2, ing );
+  EXPECT_EQ(VectorDouble3(6.5,0,5.0),vec);
+  vec  = MinImageVector  ( vec2, vec1, ing );
+  EXPECT_EQ(VectorDouble3(-6.5,0,-5.0),vec);
+  dist = MinImageDistance( vec1, vec2, ing );
+  EXPECT_NEAR(8.2,dist,0.01);
+  
 }


### PR DESCRIPTION
There was no VectorDouble3 implementation, this is a proposal.

The documentation still does not work, when clicking on the functions you are not redirected to the details.... any ideas why?

