### PR TITLE
Feature Spring Potential

### DIFF
--- a/include/LeMonADE/feature/FeatureSpringPotentialTwoGroups.h
+++ b/include/LeMonADE/feature/FeatureSpringPotentialTwoGroups.h
@@ -619,10 +619,7 @@ bool FeatureSpringPotentialTwoGroups::checkMove(const IngredientsType& ingredien
 	 * V=k/2*(|R_COM|-R_0)^2
 	 * R_COM=R1-R2
 	 * dV=V(R_COM(unmoved))-V(R_COM(moved))
-	 * the simplified equation below assumes a step length of 1 !!!
 	 */
-	
-	//seems to be shorter...
 	double 	dV  = 0.5*projected_move.getLength()*projected_move.getLength()/(size_moved_group*size_moved_group);
 		dV += equilibrium_length*(rel_length_old-rel_length_moved);
 		dV += projected_move/size_moved_group*(COM_position_old-COM_position_not_moved);

--- a/include/LeMonADE/feature/FeatureSpringPotentialTwoGroups.h
+++ b/include/LeMonADE/feature/FeatureSpringPotentialTwoGroups.h
@@ -104,10 +104,10 @@ public:
 	bool checkMove(const IngredientsType& ingredients, const MoveBase& move)const;
 	
 	template<class IngredientsType>
-	bool checkMove(const IngredientsType& ingredients,MoveLocalSc& move) const;
+	bool checkMove(const IngredientsType& ingredients, MoveLocalSc& move) const;
 
 	template<class IngredientsType>
-	bool checkMove(const IngredientsType& ingredients,MoveLocalScDiag& move) const;
+	bool checkMove(const IngredientsType& ingredients, MoveLocalScDiag& move) const;
 	
 	//! getter function for the harmonic potential spring length r0 in V(r)=k/2(r-r0)^2
 	double getEquilibriumLength() const{
@@ -143,7 +143,7 @@ public:
 	void synchronize(IngredientsType& ingredients);
 
 private:
-	//! equlibrium length r0 in harmonic potential V(r)=k/2(r-r0)^2
+	//! equilibrium length r0 in harmonic potential V(r)=k/2(r-r0)^2
 	double equilibrium_length;
 
 	//! spring constant k in harmonic potential V(r)=k/2(r-r0)^2
@@ -288,7 +288,7 @@ void ReadSpringPotentialGroups<IngredientsType>::execute()
       throw std::runtime_error(messagestream.str());
     }
 
-    //throw exception, if next character isnt "-"
+    //throw exception, if next character is not "-"
     if(!this->findSeparator(stream,'-')){
 
         std::stringstream messagestream;
@@ -309,7 +309,7 @@ void ReadSpringPotentialGroups<IngredientsType>::execute()
       throw std::runtime_error(messagestream.str());
     }
 
-    //throw exception, if next character isnt ":"
+    //throw exception, if next character is not ":"
     if(!this->findSeparator(stream,':')){
 
         std::stringstream messagestream;
@@ -494,7 +494,7 @@ bool FeatureSpringPotentialTwoGroups::checkMove(const IngredientsType& ingredien
  * It passes the corresponding move probability to FeatureBoltzmann. 
  *
  * @param [in] ingredients A reference to the IngredientsType - mainly the system
- * @param [in] move the standard simple cubic lattive move: MoveLocalSc
+ * @param [in] move the standard simple cubic lattice move: MoveLocalSc
  */
 template<class IngredientsType>
 bool FeatureSpringPotentialTwoGroups::checkMove(const IngredientsType& ingredients, MoveLocalSc& move) const
@@ -503,7 +503,7 @@ bool FeatureSpringPotentialTwoGroups::checkMove(const IngredientsType& ingredien
 	uint32_t monoIndex=move.getIndex();
 
 	//if the moved monomer has the same attribute as the affectedMonomerType,
-	//get the z position of the group afer a hypothetical move
+	//get the z position of the group after a hypothetical move
 	//otherwise return true right away
 	int32_t moveGroupTag=ingredients.getMolecules()[move.getIndex()].getMonomerGroupTag();
 
@@ -511,7 +511,7 @@ bool FeatureSpringPotentialTwoGroups::checkMove(const IngredientsType& ingredien
 	VectorDouble3 COM_position_old;
 	//this is the COM of the group where the monomer does not belong to 
 	VectorDouble3 COM_position_not_moved;
-	//number of monomers which belong to the group of the potentialy moved monomer
+	//number of monomers which belong to the group of the potentially moved monomer
 	double size_moved_group = 0.0;
 	
 	VectorDouble3 projected_move = move.getDir();
@@ -571,7 +571,7 @@ bool FeatureSpringPotentialTwoGroups::checkMove(const IngredientsType& ingredien
  * It passes the corresponding move probability to FeatureBoltzmann. 
  *
  * @param [in] ingredients A reference to the IngredientsType - mainly the system
- * @param [in] move the simple cubic lattive move: MoveLocalScDiag
+ * @param [in] move the simple cubic lattice move: MoveLocalScDiag
  */
 template<class IngredientsType>
 bool FeatureSpringPotentialTwoGroups::checkMove(const IngredientsType& ingredients, MoveLocalScDiag& move) const
@@ -580,7 +580,7 @@ bool FeatureSpringPotentialTwoGroups::checkMove(const IngredientsType& ingredien
 	uint32_t monoIndex=move.getIndex();
 
 	//if the moved monomer has the same attribute as the affectedMonomerType,
-	//get the z position of the group afer a hypothetical move
+	//get the z position of the group after a hypothetical move
 	//otherwise return true right away
 	int32_t moveGroupTag=ingredients.getMolecules()[move.getIndex()].getMonomerGroupTag();
 
@@ -588,7 +588,7 @@ bool FeatureSpringPotentialTwoGroups::checkMove(const IngredientsType& ingredien
 	VectorDouble3 COM_position_old;
 	//this is the COM of the group where the monomer does not belong to 
 	VectorDouble3 COM_position_not_moved;
-	//number of monomers which belong to the group of the potentialy moved monomer
+	//number of monomers which belong to the group of the potentially moved monomer
 	double size_moved_group = 0.0;
 	
 	VectorDouble3 projected_move = move.getDir();
@@ -643,7 +643,7 @@ bool FeatureSpringPotentialTwoGroups::checkMove(const IngredientsType& ingredien
  *   Clear the monomer groups and refill them by reading the monomer Groups Tag.
  *
  * @param [in] ingredients A reference to the IngredientsType - mainly the system
- * @param [in] the standard simple cubic lattive move: MoveLocalSc
+ * @param [in] the standard simple cubic lattice move: MoveLocalSc
  */
 template<class IngredientsType>
 void FeatureSpringPotentialTwoGroups::synchronize(IngredientsType& ingredients)
@@ -690,9 +690,6 @@ VectorDouble3 FeatureSpringPotentialTwoGroups::getGroupCenterOfMass(const Ingred
 	}
 	return VectorDouble3(sumX,sumY,sumZ)/(group.size());
 }
-
-
-
 
 
 #endif /*FEATURE_SPRINGPOTENTIAL_TWOGROUPS_H_H*/

--- a/include/LeMonADE/feature/FeatureSpringPotentialTwoGroups.h
+++ b/include/LeMonADE/feature/FeatureSpringPotentialTwoGroups.h
@@ -229,7 +229,7 @@ void ReadSpringPotentialGroups<IngredientsType>::execute()
   std::streampos previous;
   //for convenience: get the input stream
   std::istream& source=this->getInputStream();
-  //for convenience: get the set of monomers
+	//for convenience: get the set of monomers
   typename IngredientsType::molecules_type& molecules=this->getDestination().modifyMolecules();
 
   //go to next line and save the position of the get pointer into streampos previous
@@ -317,9 +317,9 @@ void ReadSpringPotentialGroups<IngredientsType>::execute()
 template<class IngredientsType>
 void FeatureSpringPotentialTwoGroups::exportRead(FileImport< IngredientsType >& fileReader)
 {
-    fileReader.registerRead("#!spring_potential_constant", new ReadVirtualSpringConstant<FeatureSpringPotentialTwoGroups>(*this));
-    fileReader.registerRead("#!spring_potential_length", new ReadVirtualSpringLength<FeatureSpringPotentialTwoGroups>(*this));
-    fileReader.registerRead("!spring_potential_groups", new ReadSpringPotentialGroups<FeatureSpringPotentialTwoGroups>(*this));
+    fileReader.registerRead("#!spring_potential_constant", new ReadVirtualSpringConstant<IngredientsType>(fileReader.getDestination()));
+    fileReader.registerRead("#!spring_potential_length", new ReadVirtualSpringLength<IngredientsType>(fileReader.getDestination()));
+    fileReader.registerRead("!spring_potential_groups", new ReadSpringPotentialGroups<IngredientsType>(fileReader.getDestination()));
 }
 
 /***************************************************************************************/
@@ -334,7 +334,7 @@ template <class IngredientsType>
 class WriteVirtualSpringConstant:public AbstractWrite<IngredientsType>
 {
 public:
-	WriteVirtualSpringConstant(const IngredientsType& i):AbstractWrite<IngredientsType>(i){this->setHeaderOnly(true);}
+	WriteVirtualSpringConstant(const IngredientsType& ing):AbstractWrite<IngredientsType>(ing){this->setHeaderOnly(true);}
 
 	virtual ~WriteVirtualSpringConstant(){}
 
@@ -358,7 +358,7 @@ template <class IngredientsType>
 class WriteVirtualSpringLength:public AbstractWrite<IngredientsType>
 {
 public:
-	WriteVirtualSpringLength(const IngredientsType& i):AbstractWrite<IngredientsType>(i){this->setHeaderOnly(true);}
+	WriteVirtualSpringLength(const IngredientsType& ing):AbstractWrite<IngredientsType>(ing){this->setHeaderOnly(true);}
 
 	virtual ~WriteVirtualSpringLength(){}
 
@@ -383,8 +383,8 @@ class WriteSpringPotentialGroups:public AbstractWrite<IngredientsType>
 {
 public:
 	//! Only writes \b !attributes into the header of the bfm-file.
-  WriteSpringPotentialGroups(const IngredientsType& i)
-    :AbstractWrite<IngredientsType>(i){this->setHeaderOnly(true);}
+  WriteSpringPotentialGroups(const IngredientsType& ing)
+    :AbstractWrite<IngredientsType>(ing){this->setHeaderOnly(true);}
   virtual ~WriteSpringPotentialGroups(){}
   virtual void writeStream(std::ostream& strm);
 };
@@ -401,13 +401,13 @@ void WriteSpringPotentialGroups<IngredientsType>::writeStream(std::ostream& strm
   //get reference to monomers
   const typename IngredientsType::molecules_type& molecules=this->getSource().getMolecules();
 
-  size_t nMonomers=molecules.size();
+  size_t nMonomers = molecules.size();
   //groupTag blocks begin with startIndex
   size_t startIndex=0;
   //counter varable
   size_t n=0;
   //groupTag to be written (updated in loop below)
-  uint8_t groupTag=molecules[0].getMonomerGroupTag();
+  uint8_t groupTag = molecules[0].getMonomerGroupTag();
 
   //write groupTags (blockwise)
   while(n<nMonomers){
@@ -416,7 +416,7 @@ void WriteSpringPotentialGroups<IngredientsType>::writeStream(std::ostream& strm
 			if(groupTag != FeatureSpringPotentialTwoGroups::UNAFFECTED){
 				strm<<startIndex+1<<"-"<<n<<":"<<groupTag<<std::endl;
 			}
-      groupTag=molecules[n].getMonomerGroupTag();
+      groupTag = molecules[n].getMonomerGroupTag();
       startIndex=n;
     }
     n++;
@@ -431,9 +431,9 @@ void WriteSpringPotentialGroups<IngredientsType>::writeStream(std::ostream& strm
 template<class IngredientsType>
 void FeatureSpringPotentialTwoGroups::exportWrite(AnalyzerWriteBfmFile<IngredientsType>& fileWriter) const
 {
-	fileWriter.registerWrite("#!spring_potential_constant",new WriteVirtualSpringConstant<FeatureSpringPotentialTwoGroups>(*this));
-	fileWriter.registerWrite("#!spring_potential_length",new WriteVirtualSpringLength<FeatureSpringPotentialTwoGroups>(*this));
-	fileWriter.registerWrite("!spring_potential_groups",new WriteSpringPotentialGroups<FeatureSpringPotentialTwoGroups>(*this));
+	fileWriter.registerWrite("#!spring_potential_constant",new WriteVirtualSpringConstant<IngredientsType>(fileWriter.getIngredients_()));
+	fileWriter.registerWrite("#!spring_potential_length",new WriteVirtualSpringLength<IngredientsType>(fileWriter.getIngredients_()));
+	fileWriter.registerWrite("!spring_potential_groups",new WriteSpringPotentialGroups<IngredientsType>(fileWriter.getIngredients_()));
 }
 
 /***************************************************************************************/
@@ -466,7 +466,6 @@ bool FeatureSpringPotentialTwoGroups::checkMove(const IngredientsType& ingredien
 {
 	//Index of moved Monomer is monoIndex
 	uint32_t monoIndex=move.getIndex();
-	const typename IngredientsType::molecules_type& molecules=ingredients.getMolecules();
 
 	//if the moved monomer has the same attribute as the affectedMonomerType,
 	//get the z position of the group afer a hypothetical move

--- a/include/LeMonADE/feature/FeatureSpringPotentialTwoGroups.h
+++ b/include/LeMonADE/feature/FeatureSpringPotentialTwoGroups.h
@@ -1,0 +1,449 @@
+/*--------------------------------------------------------------------------------
+    ooo      L   attice-based  |
+  o\.|./o    e   xtensible     | LeMonADE: An Open Source Implementation of the
+ o\.\|/./o   Mon te-Carlo      |           Bond-Fluctuation-Model for Polymers
+oo---0---oo  A   lgorithm and  |
+ o/./|\.\o   D   evelopment    | Copyright (C) 2013-2015 by 
+  o/.|.\o    E   nvironment    | LeMonADE Principal Developers (see AUTHORS)
+    ooo                        | 
+----------------------------------------------------------------------------------
+
+This file is part of LeMonADE.
+
+LeMonADE is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+LeMonADE is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with LeMonADE.  If not, see <http://www.gnu.org/licenses/>.
+
+--------------------------------------------------------------------------------*/
+
+#ifndef FEATURE_SPRINGPOTENTIAL_TWOGROUPS_H
+#define FEATURE_SPRINGPOTENTIAL_TWOGROUPS_H
+
+#include <LeMonADE/feature/Feature.h>
+#include <LeMonADE/updater/moves/MoveBase.h>
+#include <LeMonADE/updater/moves/MoveLocalSc.h>
+#include <LeMonADE/io/FileImport.h>
+#include <LeMonADE/analyzer/AnalyzerWriteBfmFile.h>
+#include <LeMonADE/feature/FeatureBoltzmann.h>
+#include <LeMonADE/feature/FeatureAttributes.h>
+
+class FeatureSpringPotentialTwoGroups:public Feature
+{
+public:
+	FeatureSpringPotentialTwoGroups(){};
+	virtual ~FeatureSpringPotentialTwoGroups(){};
+	
+	typedef LOKI_TYPELIST_2(FeatureAttributes<>, FeatureBoltzmann) required_features_back;
+	
+	template<class IngredientsType>
+	bool checkMove(const IngredientsType& ingredients, const MoveBase& move)const;
+	
+	template<class IngredientsType>
+	bool checkMove(const IngredientsType& ingredients,MoveLocalSc& move) const;
+	
+	double getEquilibriumLength() const{
+		return equilibrium_length;
+	}
+
+	void setEquilibriumLength(double equilibriumLength) {
+		equilibrium_length = equilibriumLength;
+	}
+
+	double getSpringConstant() const{
+		return spring_constant;
+	}
+
+	void setSpringConstant(double springConstant){
+		spring_constant = springConstant;
+	}
+
+	int32_t getAffectedMonomerType0() const {
+		return affectedMonomerType0;
+	}
+
+	void setAffectedMonomerType0(int32_t affectedMonomerType0) {
+		this->affectedMonomerType0 = affectedMonomerType0;
+	}
+
+	int32_t getAffectedMonomerType1() const {
+		return affectedMonomerType1;
+	}
+	void setAffectedMonomerType1(int32_t affectedMonomerType1) {
+		this->affectedMonomerType1 = affectedMonomerType1;
+	}
+
+	template<class IngredientsType>
+	VectorDouble3 getGroupCenterOfMass(const IngredientsType& ingredients,const std::vector<uint32_t>& group) const;
+
+	template<class IngredientsType>
+	void exportRead(FileImport <IngredientsType>& fileReader);
+	
+	template<class IngredientsType>
+	void exportWrite(AnalyzerWriteBfmFile <IngredientsType>& fileWriter) const;
+
+	template<class IngredientsType>
+	void synchronize(IngredientsType& ingredients);
+
+private:
+	//! equlibrium length r0 in harmonic potential V(r)=k/2(r-r0)^2
+	double equilibrium_length;
+
+	//! spring constant k in harmonic potential V(r)=k/2(r-r0)^2
+	double spring_constant;
+	
+	//attribute tag of the monomer type affected by the potential
+	int32_t affectedMonomerType0;
+
+	//contains the indices of the monomers of type affectedMonomerType
+	std::vector<uint32_t> affectedMonomerGroup0;
+
+	//attribute tag of the monomer type affected by the potential
+	int32_t affectedMonomerType1;
+
+	//contains the indices of the monomers of type affectedMonomerType
+	std::vector<uint32_t> affectedMonomerGroup1;
+
+};
+
+
+
+template<class IngredientsType>
+class ReadVirtualSpringConstant:public ReadToDestination<IngredientsType>
+{
+public:
+	ReadVirtualSpringConstant(IngredientsType& ingredients):ReadToDestination<IngredientsType>(ingredients){};
+
+	virtual ~ReadVirtualSpringConstant(){};
+	virtual void execute();
+};
+
+template<class IngredientsType>
+void ReadVirtualSpringConstant<IngredientsType>::execute()
+{
+	std::cout<<"reading VirtualSpringConstant...";
+
+	double springConstant = 0.0;
+	IngredientsType& ingredients=this->getDestination();
+	std::istream& source=this->getInputStream();
+
+	std::string line;
+	getline(source,line);
+	springConstant = atof(line.c_str());
+	std::cout << "#!virtual_spring_constant=" << (springConstant) << std::endl;
+
+	ingredients.setSpringConstant(springConstant);
+}
+
+template < class IngredientsType>
+class ReadVirtualSpringLength: public ReadToDestination<IngredientsType>
+{
+public:
+	ReadVirtualSpringLength(IngredientsType& ingredients):ReadToDestination<IngredientsType>(ingredients){}
+  virtual ~ReadVirtualSpringLength(){}
+  virtual void execute();
+};
+
+template<class IngredientsType>
+void ReadVirtualSpringLength<IngredientsType>::execute()
+{
+	std::cout<<"reading VirtualSpringLength...";
+
+	double springLength = 0.0;
+	IngredientsType& ingredients=this->getDestination();
+	std::istream& source=this->getInputStream();
+
+	std::string line;
+	getline(source,line);
+	springLength = atof(line.c_str());
+	std::cout << "#!virtual_spring_length=" << (springLength) << std::endl;
+
+	ingredients.setEquilibriumLength(springLength);
+}
+
+template < class IngredientsType>
+class ReadVirtualSpringType0: public ReadToDestination<IngredientsType>
+{
+public:
+	ReadVirtualSpringType0(IngredientsType& i):ReadToDestination<IngredientsType>(i){}
+  virtual ~ReadVirtualSpringType0(){}
+  virtual void execute();
+};
+
+template<class IngredientsType>
+void ReadVirtualSpringType0<IngredientsType>::execute()
+{
+	std::cout<<"reading VirtualSpringType0...";
+
+	int32_t springType0 = 0;
+	IngredientsType& ingredients=this->getDestination();
+	std::istream& source=this->getInputStream();
+
+	std::string line;
+	getline(source,line);
+	springType0 = atoi(line.c_str());
+	std::cout << "#!virtual_spring_type0=" << (springType0) << std::endl;
+
+	ingredients.setAffectedMonomerType0(springType0);
+}
+
+template < class IngredientsType>
+class ReadVirtualSpringType1: public ReadToDestination<IngredientsType>
+{
+public:
+	ReadVirtualSpringType1(IngredientsType& i):ReadToDestination<IngredientsType>(i){}
+  virtual ~ReadVirtualSpringType1(){}
+  virtual void execute();
+};
+
+
+
+template<class IngredientsType>
+void ReadVirtualSpringType1<IngredientsType>::execute()
+{
+	std::cout<<"reading VirtualSpringType1...";
+
+	int32_t springType1 = 0;
+	IngredientsType& ingredients=this->getDestination();
+	std::istream& source=this->getInputStream();
+
+	std::string line;
+	getline(source,line);
+	springType1 = atoi(line.c_str());
+	std::cout << "#!virtual_spring_type1=" << (springType1) << std::endl;
+
+	ingredients.setAffectedMonomerType1(springType1);
+}
+
+template<class IngredientsType>
+void FeatureSpringPotentialTwoGroups::exportRead(FileImport< IngredientsType >& fileReader)
+{
+    fileReader.registerRead("#!virtual_spring_constant", new ReadVirtualSpringConstant<FeatureSpringPotentialTwoGroups>(*this));
+    fileReader.registerRead("#!virtual_spring_length", new ReadVirtualSpringLength<FeatureSpringPotentialTwoGroups>(*this));
+    fileReader.registerRead("#!virtual_spring_type0", new ReadVirtualSpringType0<FeatureSpringPotentialTwoGroups>(*this));
+    fileReader.registerRead("#!virtual_spring_type1", new ReadVirtualSpringType1<FeatureSpringPotentialTwoGroups>(*this));
+
+}
+
+/***************************************************************************************/
+
+
+template <class IngredientsType>
+class WriteVirtualSpringConstant:public AbstractWrite<IngredientsType>
+{
+public:
+	WriteVirtualSpringConstant(const IngredientsType& i):AbstractWrite<IngredientsType>(i){this->setHeaderOnly(true);}
+
+	virtual ~WriteVirtualSpringConstant(){}
+
+	virtual void writeStream(std::ostream& strm);
+};
+
+template<class IngredientsType>
+void WriteVirtualSpringConstant<IngredientsType>::writeStream(std::ostream& stream)
+{
+	stream<<"#!virtual_spring_constant=" << (this->getSource().getSpringConstant()) << std::endl<< std::endl;
+}
+
+/*****************************************************************/
+/**
+ * @class WriteVirtualSpringLength
+ *
+ * @brief Handles BFM-File-Write \b #!VirtualSpringLength
+ * @tparam IngredientsType Ingredients class storing all system information.
+ **/
+template <class IngredientsType>
+class WriteVirtualSpringLength:public AbstractWrite<IngredientsType>
+{
+public:
+	WriteVirtualSpringLength(const IngredientsType& i):AbstractWrite<IngredientsType>(i){this->setHeaderOnly(true);}
+
+	virtual ~WriteVirtualSpringLength(){}
+
+	virtual void writeStream(std::ostream& strm);
+};
+
+template<class IngredientsType>
+void WriteVirtualSpringLength<IngredientsType>::writeStream(std::ostream& stream)
+{
+	stream<<"#!virtual_spring_length=" << (this->getSource().getEquilibriumLength()) << std::endl<< std::endl;
+}
+
+
+/*****************************************************************/
+/**
+ * @class WriteVirtualSpringType0
+ *
+ * @brief Handles BFM-File-Write \b #!VirtualSpringType0
+ * @tparam IngredientsType Ingredients class storing all system information.
+ **/
+template <class IngredientsType>
+class WriteVirtualSpringType0:public AbstractWrite<IngredientsType>
+{
+public:
+	WriteVirtualSpringType0(const IngredientsType& i):AbstractWrite<IngredientsType>(i){this->setHeaderOnly(true);}
+
+	virtual ~WriteVirtualSpringType0(){}
+
+	virtual void writeStream(std::ostream& strm);
+};
+
+template<class IngredientsType>
+void WriteVirtualSpringType0<IngredientsType>::writeStream(std::ostream& stream)
+{
+	stream<<"#!virtual_spring_type0=" << (this->getSource().getAffectedMonomerType0()) << std::endl<< std::endl;
+}
+
+
+template <class IngredientsType>
+class WriteVirtualSpringType1:public AbstractWrite<IngredientsType>
+{
+public:
+	WriteVirtualSpringType1(const IngredientsType& i):AbstractWrite<IngredientsType>(i){this->setHeaderOnly(true);}
+
+	virtual ~WriteVirtualSpringType1(){}
+
+	virtual void writeStream(std::ostream& strm);
+};
+
+template<class IngredientsType>
+void WriteVirtualSpringType1<IngredientsType>::writeStream(std::ostream& stream)
+{
+	stream<<"#!virtual_spring_type1=" << (this->getSource().getAffectedMonomerType1()) << std::endl<< std::endl;
+}
+
+
+
+template<class IngredientsType>
+void FeatureSpringPotentialTwoGroups::exportWrite(AnalyzerWriteBfmFile<IngredientsType>& fileWriter) const
+{
+	fileWriter.registerWrite("#!virtual_spring_constant",new WriteVirtualSpringConstant<FeatureSpringPotentialTwoGroups>(*this));
+	fileWriter.registerWrite("#!virtual_spring_length",new WriteVirtualSpringLength<FeatureSpringPotentialTwoGroups>(*this));
+	fileWriter.registerWrite("#!virtual_spring_type0",new WriteVirtualSpringType0<FeatureSpringPotentialTwoGroups>(*this));
+	fileWriter.registerWrite("#!virtual_spring_type1",new WriteVirtualSpringType1<FeatureSpringPotentialTwoGroups>(*this));
+}
+
+template<class IngredientsType>
+bool FeatureSpringPotentialTwoGroups::checkMove(const IngredientsType& ingredients, const MoveBase& move) const
+{
+	return true;
+}
+
+
+template<class IngredientsType>
+bool FeatureSpringPotentialTwoGroups::checkMove(const IngredientsType& ingredients, MoveLocalSc& move)const
+{
+	//Index of moved Monomer is monoIndex
+	uint32_t monoIndex=move.getIndex();
+	const typename IngredientsType::molecules_type& molecules=ingredients.getMolecules();
+
+	//if the moved monomer has the same attribute as the affectedMonomerType,
+	//get the z position of the group afer a hypothetical move
+	//otherwise return true right away
+	int32_t attributeTagMoveObject=ingredients.getMolecules()[move.getIndex()].getAttributeTag();
+
+	VectorDouble3 COM_position_old;
+	VectorDouble3 COM_position_not_moved;
+	double size_moved_group = 0.0;
+
+
+	VectorDouble3 projected_move = move.getDir();
+
+	if(attributeTagMoveObject==affectedMonomerType0)
+	{
+		COM_position_old=getGroupCenterOfMass(ingredients,affectedMonomerGroup0);
+		COM_position_not_moved=getGroupCenterOfMass(ingredients,affectedMonomerGroup1);
+		size_moved_group=affectedMonomerGroup0.size();
+	}
+	else if(attributeTagMoveObject==affectedMonomerType1)
+	{
+		COM_position_old=getGroupCenterOfMass(ingredients,affectedMonomerGroup1);
+		COM_position_not_moved=getGroupCenterOfMass(ingredients,affectedMonomerGroup0);
+		size_moved_group=affectedMonomerGroup1.size();
+	}
+	else return true;
+
+	//the rest happens only if we have not returned yet, i.e. if distance has been calculated
+
+	VectorDouble3 rel_length_old(COM_position_old-COM_position_not_moved);
+	VectorDouble3 rel_length_moved(COM_position_old-COM_position_not_moved+projected_move/size_moved_group);
+
+	// calculate the potential difference
+	double dV = spring_constant*(COM_position_old*projected_move/size_moved_group);
+	dV += 0.5*spring_constant/(size_moved_group*size_moved_group);
+	dV -= spring_constant*(COM_position_not_moved*projected_move/size_moved_group);
+	dV += spring_constant*equilibrium_length*(rel_length_old.getLength()-rel_length_moved.getLength());
+
+	//calculate the transition probability
+	//Metropolis: zeta = exp (-dV)
+	double prob=exp(-dV);
+
+	//std::cout << "prob: " <<  prob << std::endl;
+	move.multiplyProbability(prob);
+
+	return true;
+
+}
+
+//finds the indices of the affected monomers and checks if the
+//center of mass is in a valid position, i.e. that the potential is not
+//infinite
+template<class IngredientsType>
+void FeatureSpringPotentialTwoGroups::synchronize(IngredientsType& ingredients)
+{
+	// delete the old content
+	affectedMonomerGroup0.clear();
+	affectedMonomerGroup1.clear();
+
+	//sort the monomers into groups
+	for(size_t n=0;n<ingredients.getMolecules().size();n++)
+	{
+		if(ingredients.getMolecules()[n].getAttributeTag()==affectedMonomerType0)
+		{
+			affectedMonomerGroup0.push_back(n);
+		}
+
+		if(ingredients.getMolecules()[n].getAttributeTag()==affectedMonomerType1)
+		{
+			affectedMonomerGroup1.push_back(n);
+		}
+	}
+
+	std::cout<<"FeatureSpringPotentialTwoGroups::synchronize()...affected group size 1 ="<<affectedMonomerGroup0.size()<<
+			"...affected group size 2 ="<<affectedMonomerGroup1.size()<<std::endl;
+
+}
+
+template<class IngredientsType>
+VectorDouble3 FeatureSpringPotentialTwoGroups::getGroupCenterOfMass(const IngredientsType& ingredients, const std::vector<uint32_t>& group) const
+{
+	//the default for index is 0, the default for direction is 0,0,0. the index 0 points to a particle,
+	//but since one has to explicitly specify index if one changes direction to anything other than 0,0,0
+	//there is no danger in using the function without explicit arguments
+
+	int32_t sumX=0;
+	int32_t sumY=0;
+	int32_t sumZ=0;
+	for(size_t n=0;n<group.size();n++)
+	{
+			sumX+=ingredients.getMolecules()[group[n]].getX();
+			sumY+=ingredients.getMolecules()[group[n]].getY();
+			sumZ+=ingredients.getMolecules()[group[n]].getZ();
+
+	}
+	return VectorDouble3(sumX,sumY,sumZ)/(group.size());
+}
+
+
+
+
+
+#endif /*FEATURE_SPRINGPOTENTIAL_TWOGROUPS_H_H*/

--- a/tests/feature/TestFeatureSpringPotentialTwoGroups.cpp
+++ b/tests/feature/TestFeatureSpringPotentialTwoGroups.cpp
@@ -1,9 +1,9 @@
 /*****************************************************************************/
 /**
  * @file
- * @brief test for Feature Virtual Spring towards a wall in z-direction
+ * @brief test for Feature Spring Potential
  * @author Martin
- * @date 31.08.2017
+ * @date 08.05.2019
  * */
 /*****************************************************************************/
 #include "gtest/gtest.h"
@@ -15,7 +15,7 @@
 #include <LeMonADE/core/Ingredients.h>
 #include <LeMonADE/feature/FeatureMoleculesIO.h>
 
-#include "FeatureSpringPotentialTwoGroups.h"
+#include <LeMonADE/feature/FeatureSpringPotentialTwoGroups.h>
 
 
 class TestFeatureSpringPotentialTwoGroups: public ::testing::Test{
@@ -42,19 +42,45 @@ private:
 };
 
 
-//   TEST_F(TestFeatureSpringPotentialTwoGroups,Constructor){
-//     // test default constructor
-//     FeatureVirtualSpringWall feature;
-//     EXPECT_DOUBLE_EQ(0.0,feature.getEquilibriumLength());
-//     EXPECT_DOUBLE_EQ(0.0,feature.getSpringConstant());
-//     EXPECT_EQ(0,feature.getAffectedMonomerType());
-//     
-//     //test constructor in ingredients
-//     EXPECT_DOUBLE_EQ(0.0,ingredients.getEquilibriumLength());
-//     EXPECT_DOUBLE_EQ(0.0,ingredients.getSpringConstant());
-//     EXPECT_EQ(0,ingredients.getAffectedMonomerType());
-//     
-//   }
+TEST_F(TestFeatureSpringPotentialTwoGroups,Basics){
+  // test default constructor
+  FeatureSpringPotentialTwoGroups feature;
+  EXPECT_DOUBLE_EQ(0.0,feature.getEquilibriumLength());
+  EXPECT_DOUBLE_EQ(0.0,feature.getSpringConstant());
+  
+  //test constructor in ingredients
+  EXPECT_DOUBLE_EQ(0.0,ingredients.getEquilibriumLength());
+  EXPECT_DOUBLE_EQ(0.0,ingredients.getSpringConstant());
+
+  //setup a small system
+  ingredients.setSpringConstant(0.25);
+  ingredients.setEquilibriumLength(4);
+  ingredients.setBoxX(16);
+  ingredients.setBoxY(16);
+  ingredients.setBoxZ(16);
+  ingredients.setPeriodicX(true);
+  ingredients.setPeriodicY(true);
+  ingredients.setPeriodicZ(true);
+  ingredients.modifyBondset().addBFMclassicBondset();
+  ingredients.modifyMolecules().addMonomer(0,0,0);
+
+  // check the spring parameters and the monomer extension
+  EXPECT_DOUBLE_EQ(4.00,ingredients.getEquilibriumLength());
+  EXPECT_DOUBLE_EQ(0.25,ingredients.getSpringConstant());
+  EXPECT_EQ(0,ingredients.getMolecules()[0].getMonomerGroupTag());
+
+  // check the monomer extension setter and getter
+  EXPECT_NO_THROW(ingredients.modifyMolecules()[0].setMonomerGroupTag(1));
+  EXPECT_EQ(1,ingredients.getMolecules()[0].getMonomerGroupTag());
+  EXPECT_NO_THROW(ingredients.modifyMolecules()[0].setMonomerGroupTag(2));
+  EXPECT_EQ(2,ingredients.getMolecules()[0].getMonomerGroupTag());
+  EXPECT_NO_THROW(ingredients.modifyMolecules()[0].setMonomerGroupTag(0));
+  EXPECT_EQ(0,ingredients.getMolecules()[0].getMonomerGroupTag());
+
+  // other values than 0,1,2 are not allowed
+  EXPECT_ANY_THROW(ingredients.modifyMolecules()[0].setMonomerGroupTag(3));
+  
+}
 //   
 //   TEST_F(TestFeatureSpringPotentialTwoGroups,InitializeGroupSorting){
 //     //setup 

--- a/tests/feature/TestFeatureSpringPotentialTwoGroups.cpp
+++ b/tests/feature/TestFeatureSpringPotentialTwoGroups.cpp
@@ -75,14 +75,14 @@ public:
   
   /* suppress cout output for better readability -->un-/comment here: */
   //redirect cout output
-  virtual void SetUp(){
-    originalBuffer=std::cout.rdbuf();
-    std::cout.rdbuf(tempStream.rdbuf());
-  };
-  //restore original output
-  virtual void TearDown(){
-    std::cout.rdbuf(originalBuffer);
-  };
+//   virtual void SetUp(){
+//     originalBuffer=std::cout.rdbuf();
+//     std::cout.rdbuf(tempStream.rdbuf());
+//   };
+//   //restore original output
+//   virtual void TearDown(){
+//     std::cout.rdbuf(originalBuffer);
+//   };
 private:
   std::streambuf* originalBuffer;
   std::ostringstream tempStream;
@@ -201,6 +201,7 @@ TEST_F(TestFeatureSpringPotentialTwoGroups,MoveChecks){
       scmove.apply(ingredients);
       if( scmove.getIndex() == 2 ){
         EXPECT_FALSE(referencePosition == ingredients.getMolecules()[2]);
+	referencePosition=ingredients.getMolecules()[2];
         counter++;
       }
     }

--- a/tests/feature/TestFeatureSpringPotentialTwoGroups.cpp
+++ b/tests/feature/TestFeatureSpringPotentialTwoGroups.cpp
@@ -76,14 +76,14 @@ public:
   
   /* suppress cout output for better readability -->un-/comment here: */
   //redirect cout output
-//   virtual void SetUp(){
-//     originalBuffer=std::cout.rdbuf();
-//     std::cout.rdbuf(tempStream.rdbuf());
-//   };
-//   //restore original output
-//   virtual void TearDown(){
-//     std::cout.rdbuf(originalBuffer);
-//   };
+   virtual void SetUp(){
+     originalBuffer=std::cout.rdbuf();
+     std::cout.rdbuf(tempStream.rdbuf());
+   };
+   //restore original output
+   virtual void TearDown(){
+     std::cout.rdbuf(originalBuffer);
+   };
 private:
   std::streambuf* originalBuffer;
   std::ostringstream tempStream;
@@ -202,7 +202,7 @@ TEST_F(TestFeatureSpringPotentialTwoGroups,MoveChecks){
       scmove.apply(ingredients);
       if( scmove.getIndex() == 2 ){
         EXPECT_FALSE(referencePosition == ingredients.getMolecules()[2]);
-	referencePosition=ingredients.getMolecules()[2];
+	      referencePosition=ingredients.getMolecules()[2];
         counter++;
       }
     }

--- a/tests/feature/TestFeatureSpringPotentialTwoGroups.cpp
+++ b/tests/feature/TestFeatureSpringPotentialTwoGroups.cpp
@@ -1,0 +1,103 @@
+/*****************************************************************************/
+/**
+ * @file
+ * @brief test for Feature Virtual Spring towards a wall in z-direction
+ * @author Martin
+ * @date 31.08.2017
+ * */
+/*****************************************************************************/
+#include "gtest/gtest.h"
+
+
+#include <iostream>
+
+#include <LeMonADE/core/Molecules.h>
+#include <LeMonADE/core/Ingredients.h>
+#include <LeMonADE/feature/FeatureMoleculesIO.h>
+
+#include "FeatureSpringPotentialTwoGroups.h"
+
+
+class TestFeatureSpringPotentialTwoGroups: public ::testing::Test{
+public:
+  typedef LOKI_TYPELIST_2(FeatureMoleculesIO,FeatureSpringPotentialTwoGroups) Features;
+  typedef ConfigureSystem<VectorInt3,Features> ConfigType;
+  typedef Ingredients < ConfigType> IngredientsType;
+  IngredientsType ingredients;
+  
+  /* suppress cout output for better readability -->un-/comment here: */
+  //redirect cout output
+  virtual void SetUp(){
+    originalBuffer=std::cout.rdbuf();
+    std::cout.rdbuf(tempStream.rdbuf());
+  };
+  //restore original output
+  virtual void TearDown(){
+    std::cout.rdbuf(originalBuffer);
+  };
+private:
+  std::streambuf* originalBuffer;
+  std::ostringstream tempStream;
+  /* ** */
+};
+
+
+//   TEST_F(TestFeatureSpringPotentialTwoGroups,Constructor){
+//     // test default constructor
+//     FeatureVirtualSpringWall feature;
+//     EXPECT_DOUBLE_EQ(0.0,feature.getEquilibriumLength());
+//     EXPECT_DOUBLE_EQ(0.0,feature.getSpringConstant());
+//     EXPECT_EQ(0,feature.getAffectedMonomerType());
+//     
+//     //test constructor in ingredients
+//     EXPECT_DOUBLE_EQ(0.0,ingredients.getEquilibriumLength());
+//     EXPECT_DOUBLE_EQ(0.0,ingredients.getSpringConstant());
+//     EXPECT_EQ(0,ingredients.getAffectedMonomerType());
+//     
+//   }
+//   
+//   TEST_F(TestFeatureSpringPotentialTwoGroups,InitializeGroupSorting){
+//     //setup 
+//     ingredients.setAffectedMonomerType(1);
+//     ingredients.setSpringConstant(0.25);
+//     ingredients.setEquilibriumLength(4);
+//     ingredients.setBoxX(16);
+//     ingredients.setBoxY(16);
+//     ingredients.setBoxZ(16);
+//     ingredients.setPeriodicX(true);
+//     ingredients.setPeriodicY(true);
+//     ingredients.setPeriodicZ(true);
+//     ingredients.modifyBondset().addBFMclassicBondset();
+//   
+//      //molecule one
+//     ingredients.modifyMolecules().addMonomer(0,0,6);
+//     ingredients.modifyMolecules()[ingredients.getMolecules().size()-1].setAttributeTag(1);
+//     ingredients.modifyMolecules().addMonomer(2,0,6);
+//     ingredients.modifyMolecules()[ingredients.getMolecules().size()-1].setAttributeTag(1);
+//     ingredients.modifyMolecules().addMonomer(4,0,6);
+//     ingredients.modifyMolecules()[ingredients.getMolecules().size()-1].setAttributeTag(1);
+//     ingredients.modifyMolecules().connect(0,1);
+//     ingredients.modifyMolecules().connect(1,2);
+//     /*   o-o-o   */
+//     //molecule two
+//     ingredients.modifyMolecules().addMonomer(0,0,2);
+//     ingredients.modifyMolecules()[ingredients.getMolecules().size()-1].setAttributeTag(4);
+//     ingredients.modifyMolecules().addMonomer(2,0,2);
+//     ingredients.modifyMolecules()[ingredients.getMolecules().size()-1].setAttributeTag(4);
+//     ingredients.modifyMolecules().addMonomer(4,0,2);
+//     ingredients.modifyMolecules()[ingredients.getMolecules().size()-1].setAttributeTag(4);
+//     ingredients.modifyMolecules().addMonomer(6,0,2);
+//     ingredients.modifyMolecules()[ingredients.getMolecules().size()-1].setAttributeTag(4);
+//     ingredients.modifyMolecules().connect(3,4);
+//     ingredients.modifyMolecules().connect(4,5);
+//     ingredients.modifyMolecules().connect(5,6);
+//     /*   o-o-o-o  */
+//     
+//     EXPECT_NO_THROW(ingredients.synchronize());
+//     EXPECT_EQ(7,ingredients.getMolecules().size());
+//     EXPECT_EQ(3,ingredients.getAffectedMonomerGroup().size());
+//     EXPECT_EQ(0,ingredients.getAffectedMonomerGroup().at(0));
+//     EXPECT_EQ(1,ingredients.getAffectedMonomerGroup().at(1));
+//     EXPECT_EQ(2,ingredients.getAffectedMonomerGroup().at(2));
+//     
+//   }

--- a/tests/feature/TestFeatureSpringPotentialTwoGroups.cpp
+++ b/tests/feature/TestFeatureSpringPotentialTwoGroups.cpp
@@ -45,6 +45,7 @@ along with LeMonADE.  If not, see <http://www.gnu.org/licenses/>.
 #include <LeMonADE/analyzer/AnalyzerWriteBfmFile.h>
 #include <LeMonADE/updater/moves/MoveBase.h>
 #include <LeMonADE/updater/moves/MoveLocalSc.h>
+#include <LeMonADE/updater/moves/MoveLocalScDiag.h>
 
 #include <LeMonADE/feature/FeatureSpringPotentialTwoGroups.h>
 
@@ -212,6 +213,22 @@ TEST_F(TestFeatureSpringPotentialTwoGroups,MoveChecks){
   EXPECT_TRUE(abs( abs( (ingredients.getMolecules()[0]-ingredients.getMolecules()[1]).getLength()-2 ) ) < 2 );
   // there should have been some moves of the unaffected monomer
   EXPECT_TRUE(counter>0);
+  
+  //MoveLocalScDiag scmovediag;
+  MoveLocalScDiag scmovediag;
+  //reste the positions
+  ingredients.modifyMolecules()[0].modifyVector3D().setAllCoordinates(0,0,0);
+  ingredients.modifyMolecules()[1].modifyVector3D().setAllCoordinates(13,8,9);
+  
+  for(uint32_t i=0;i<100;i++){
+    scmovediag.init(ingredients);
+    if(scmovediag.check(ingredients)){
+      scmovediag.apply(ingredients);
+    }
+  }
+  // monomers should be close
+  std::cout << (ingredients.getMolecules()[0]-ingredients.getMolecules()[1]).getLength() <<std::endl;
+  EXPECT_TRUE(abs( abs( (ingredients.getMolecules()[0]-ingredients.getMolecules()[1]).getLength()-2 ) ) < 2 );
   
 }
 


### PR DESCRIPTION
This feature is used for umbrella sampling adopted from an old version from @Bondoki , see first commit of this pull request.
I added some tests and modified the read-write system. It does not depend on [FeatureAttributes](include/LeMonADE/feature/FeatureAttributes.h) anymore. The documentation is satisfying but improveable ;) 

One thing is left to do: the `std::vector<int32_t> affectedMonomerGroup` should be transfered to monomer groups and a functor for fill_connected_groups should be provided. 