### PR TITLE
Lipid bilayer tools: fix includes in tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ ADD_SUBDIRECTORY(projects)
 #
 # Add option for building tests
 #
-option(LEMONADE_TESTS "Build the test" OFF)
+option(LEMONADE_TESTS "Build the test" ON)
 if(LEMONADE_TESTS)
     add_subdirectory(tests)
 endif(LEMONADE_TESTS)

--- a/tests/updater/TestUpdaterLipidsCreator.cpp
+++ b/tests/updater/TestUpdaterLipidsCreator.cpp
@@ -47,7 +47,7 @@ along with LeMonADE.  If not, see <http://www.gnu.org/licenses/>.
 #include <LeMonADE/feature/FeatureExcludedVolumeSc.h>
 #include <LeMonADE/feature/FeatureAttributes.h>
 #include <LeMonADE/updater/UpdaterLipidsCreator.h>
-#include "TesterFunctions.h"
+#include "TesterHelperFunctionsLipids.h"
     
 using namespace std;
 

--- a/tests/updater/TestUpdaterLipidsRandomInitializer.cpp
+++ b/tests/updater/TestUpdaterLipidsRandomInitializer.cpp
@@ -47,7 +47,7 @@ along with LeMonADE.  If not, see <http://www.gnu.org/licenses/>.
 #include <LeMonADE/feature/FeatureExcludedVolumeSc.h>
 #include <LeMonADE/feature/FeatureAttributes.h>
 #include <LeMonADE/updater/UpdaterLipidsRandomInitializer.h>
-#include "TesterFunctions.h"
+#include "TesterHelperFunctionsLipids.h"
 
 using namespace std;
 


### PR DESCRIPTION
circle ci failes due to incorrect includes, this should be fixed now