### PR TITLE
Bugfix

### DIFF
--- a/include/LeMonADE/analyzer/AnalyzerAbstractDump.h
+++ b/include/LeMonADE/analyzer/AnalyzerAbstractDump.h
@@ -15,8 +15,6 @@
 #include <LeMonADE/analyzer/AbstractAnalyzer.h>
 #include <LeMonADE/utility/Vector3D.h>
 #include <LeMonADE/utility/ResultFormattingTools.h>
-#include <LeMonADE/utility/MonomerGroup.h>
-#include <LeMonADE/utility/DistanceCalculation.h>
 
 /*************************************************************************
  * definition of AnalyzerAbstractDump class
@@ -98,8 +96,12 @@ public:
 	uint32_t getNumberOfColumns(){ return NColumns; }
 	//! set the buffer size for dumping data 
 	void setBufferSize(uint32_t bufferSize_){ bufferSize=bufferSize_;}
-        //! get the buffer size
-        uint32_t getBufferSize(){return bufferSize;}
+	//! get the buffer size
+	uint32_t getBufferSize(){return bufferSize;}
+	//! get the variable isFirstFileDump 
+	bool getIsFirstFileDump() const { return isFirstFileDump; }  
+	//! reset the variable isFirstFileDump to false (could be used if the filename changes in between data dumpings)
+	void resetIsFirstFileDump() {isFirstFileDump=true;}
 };
 
 /*************************************************************************

--- a/include/LeMonADE/analyzer/AnalyzerWriteBfmFile.h
+++ b/include/LeMonADE/analyzer/AnalyzerWriteBfmFile.h
@@ -134,6 +134,11 @@ public:
    *
    **/
   virtual void cleanup(){};
+protected: 
+
+  //! set the name of the file for output which only works for the overwrite case 
+  void setFilename(std::string filename){_filename=filename;}
+
 private:
   //! Write Writes that only need to be in the header
   void writeHeader();

--- a/include/LeMonADE/feature/FeatureBondset.h
+++ b/include/LeMonADE/feature/FeatureBondset.h
@@ -223,17 +223,15 @@ class FeatureBondset : public Feature
   template<class IngredientsType,class MoveLabelType>
   bool checkMove(const IngredientsType& ingredients, const MoveLabelBase<MoveLabelType>& move) const
   {
-
-	  //get the number of bond partners of the particle to be moved
-          int32_t MonID=move.getIndex()+move.getDir();
-	  if ( MonID == -1 ) return false;
-	  uint32_t ID=move.getConnectedLabel();
-          const typename IngredientsType::molecules_type& molecules=ingredients.getMolecules();
-	  if (ID == 0 ) return true; 
-	  ID--;
-          auto bond(molecules[MonID].getVector3D()-molecules[ID].getVector3D());
-	  if (!bondset.isValidStrongCheck( bond ) ) return false; 
-      if ( bond.getLength()>3.) return false; // otherwise I could get xtraps 
+      //get the number of bond partners of the particle to be moved
+      int32_t MonID=move.getIndex()+move.getDir();
+      if ( MonID == -1 ) return false;
+      uint32_t ID=move.getConnectedLabel();
+      const typename IngredientsType::molecules_type& molecules=ingredients.getMolecules();
+      if (ID == 0 ) return true; 
+      ID--;
+      auto bond(molecules[MonID].getVector3D()-molecules[ID].getVector3D());
+      if (!bondset.isValidStrongCheck( bond ) ) return false; 
       return true;
   }
   

--- a/include/LeMonADE/updater/moves/MoveAddMonomerBase.h
+++ b/include/LeMonADE/updater/moves/MoveAddMonomerBase.h
@@ -60,7 +60,7 @@ template<class SpecializedMove, class TagType>
 class MoveAddMonomerBase:public MoveBase
 {
 public:
-  MoveAddMonomerBase():monomerTag(TagType()),reactivity(false), numMaxLinks(0){};
+  MoveAddMonomerBase():monomerTag(TagType()),reactivity(false), numMaxLinks(0), label(0){};
   //here come the functions that are implemented by the specialization
   //! Reset the probability
   template <class IngredientsType> void init(const IngredientsType& ingredients);

--- a/tests/core/TestIngredients.cpp
+++ b/tests/core/TestIngredients.cpp
@@ -125,7 +125,7 @@ TEST_F(IngredientsTest, synchronize_noargument){
 	typedef Ingredients < Config1> MyIngredients1;
 
 	typedef LOKI_TYPELIST_3(FeatureBox, FeatureBondset<>,FeatureExcludedVolumeSc<>) Features2;
-	typedef ConfigureSystem<VectorInt3,Features1,3> Config2;
+	typedef ConfigureSystem<VectorInt3,Features2,3> Config2;
 	typedef Ingredients < Config2> MyIngredients2;
 
 
@@ -210,7 +210,7 @@ TEST_F(IngredientsTest, synchronize_withargument){
 	typedef Ingredients < Config1> MyIngredients1;
 
 	typedef LOKI_TYPELIST_3(FeatureBox, FeatureBondset<>,FeatureExcludedVolumeSc<>) Features2;
-	typedef ConfigureSystem<VectorInt3,Features1,3> Config2;
+	typedef ConfigureSystem<VectorInt3,Features2,3> Config2;
 	typedef Ingredients < Config2> MyIngredients2;
 
 

--- a/tests/updater/TestMoveBreakReactive.cpp
+++ b/tests/updater/TestMoveBreakReactive.cpp
@@ -56,16 +56,16 @@ public:
 
   IngredientsType ingredients;
 
-//   //redirect cout output
-//   virtual void SetUp(){
-//     originalBuffer=std::cout.rdbuf();
-//     std::cout.rdbuf(tempStream.rdbuf());
-//   };
-// 
-//   //restore original output
-//   virtual void TearDown(){
-//     std::cout.rdbuf(originalBuffer);
-//   };
+  //redirect cout output
+  virtual void SetUp(){
+    originalBuffer=std::cout.rdbuf();
+    std::cout.rdbuf(tempStream.rdbuf());
+  };
+
+  //restore original output
+  virtual void TearDown(){
+    std::cout.rdbuf(originalBuffer);
+  };
 
 private:
   std::streambuf* originalBuffer;

--- a/tests/updater/TestMoveLocalScDiag.cpp
+++ b/tests/updater/TestMoveLocalScDiag.cpp
@@ -75,16 +75,16 @@ public:
 	steps[16]=VectorInt3(-1,1,0);
 	steps[17]=VectorInt3(-1,-1,0); 
     }
-    // //redirect cout output
-    // virtual void SetUp(){
-    //     originalBuffer=std::cout.rdbuf();
-    //     std::cout.rdbuf(tempStream.rdbuf());
-    // };
+    //redirect cout output
+    virtual void SetUp(){
+        originalBuffer=std::cout.rdbuf();
+        std::cout.rdbuf(tempStream.rdbuf());
+    };
 
-    // //restore original output
-    // virtual void TearDown(){
-    //     std::cout.rdbuf(originalBuffer);
-    // };
+    //restore original output
+    virtual void TearDown(){
+        std::cout.rdbuf(originalBuffer);
+    };
     VectorInt3 steps[18];
 private:
     std::streambuf* originalBuffer;


### PR DESCRIPTION
Several small bugs or uncertainties:
AnalyzerAbstractDump.h : to much includes 
FeatureBondset::check(MoveLabelAlongChain) ::to much checks
TestMoveBreakReactive/TestMoveLocalScDiag: to much output (to stdout)
MoveAddMonomerBase::missing initialization of member variable
TestIngredients: wrong usage of  IngredientsType 